### PR TITLE
fix tier cap per tech track

### DIFF
--- a/src/__tests__/core.spec.ts
+++ b/src/__tests__/core.spec.ts
@@ -13,11 +13,10 @@ describe('core helpers', () => {
     expect(successThreshold(10, -5)).toBe(2)
   })
 
-  it('tierCap averages and clamps 1..3', () => {
-    expect(tierCap({ Military: 1, Grid: 1, Nano: 1 })).toBe(1)
-    expect(tierCap({ Military: 3, Grid: 3, Nano: 3 })).toBe(3)
-    expect(tierCap({ Military: 1, Grid: 3, Nano: 2 })).toBeGreaterThanOrEqual(1)
-    expect(tierCap({ Military: 1, Grid: 3, Nano: 2 })).toBeLessThanOrEqual(3)
+  it('tierCap clamps each track independently between 1 and 3', () => {
+    expect(tierCap({ Military: 1, Grid: 1, Nano: 1 })).toEqual({ Military:1, Grid:1, Nano:1 })
+    expect(tierCap({ Military: 3, Grid: 3, Nano: 3 })).toEqual({ Military:3, Grid:3, Nano:3 })
+    expect(tierCap({ Military: 0, Grid: 4, Nano: 2 })).toEqual({ Military:1, Grid:3, Nano:2 })
   })
 
   it('makeShip validates required parts and power constraints', () => {

--- a/src/__tests__/runtime.selftests.spec.ts
+++ b/src/__tests__/runtime.selftests.spec.ts
@@ -10,8 +10,9 @@ describe('Runtime self-tests (moved from App)', () => {
   it('shop respects tier caps and returns requested count', () => {
     const research = {Military:1, Grid:1, Nano:1}
     const items = rollInventory(research, 8)
+    const caps = tierCap(research)
     expect(items.length).toBe(8)
-    expect(items.every(p => p.tier <= tierCap(research))).toBe(true)
+    expect(items.every(p => p.tier === caps[p.tech_category as 'Military'|'Grid'|'Nano'])).toBe(true)
   })
 
   it('makeShip valid for all frames', () => {


### PR DESCRIPTION
## Summary
- base tier caps on each tech track instead of averaging
- restrict shop inventory to items matching the player's tier per track
- adjust tests for new tier cap behavior

## Testing
- `nom run test:run` *(fails: command not found)*
- `npm run test:run`


------
https://chatgpt.com/codex/tasks/task_e_68b313b8b548833390b64c6140c92603