### PR TITLE
Refactor faction system to use centralized game config

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+Always make sure to update tests before making changes and the last step should be to run a build.

--- a/src/__tests__/factions.spec.tsx
+++ b/src/__tests__/factions.spec.tsx
@@ -1,19 +1,15 @@
 import { describe, it, expect } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
 import App from '../App'
+import { getFaction } from '../config/factions'
 
 describe('Factions', () => {
   it('Scientists start at Tier 2 across all tracks', () => {
     render(<App />)
-    // Pick Scientists
     fireEvent.click(screen.getByRole('button', { name: /Consortium of Scholars/i }))
-    // Start on Easy
     fireEvent.click(screen.getByRole('button', { name: /Easy/i }))
-    // Dismiss rules overlay to access Outpost controls
     fireEvent.click(screen.getByRole('button', { name: /Let’s go/i }))
-    // Switch to Outpost tab to see research buttons
     fireEvent.click(screen.getByRole('button', { name: /^Outpost$/i }))
-    // Should see labels like "Military 2→3 (.."
     expect(screen.getByRole('button', { name: /Military 2→3/i })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: /Grid 2→3/i })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: /Nano 2→3/i })).toBeInTheDocument()
@@ -23,7 +19,6 @@ describe('Factions', () => {
     render(<App />)
     fireEvent.click(screen.getByRole('button', { name: /Crimson Vanguard/i }))
     fireEvent.click(screen.getByRole('button', { name: /Easy/i }))
-    // In Combat view, Player ships should include a Cruiser
     expect(screen.getAllByText(/Cruiser/i).length).toBeGreaterThan(0)
   })
 
@@ -31,9 +26,7 @@ describe('Factions', () => {
     render(<App />)
     fireEvent.click(screen.getByRole('button', { name: /Void Corsairs/i }))
     fireEvent.click(screen.getByRole('button', { name: /Easy/i }))
-    // Dismiss rules overlay to access Combat view
     fireEvent.click(screen.getByRole('button', { name: /Let’s go/i }))
-    // Player card should list Antimatter Cannon among weapons
     expect(screen.getAllByText(/Antimatter Cannon/i).length).toBeGreaterThan(0)
   })
 
@@ -43,10 +36,13 @@ describe('Factions', () => {
     fireEvent.click(screen.getByRole('button', { name: /Easy/i }))
     fireEvent.click(screen.getByRole('button', { name: /Let’s go/i }))
     fireEvent.click(screen.getByRole('button', { name: /^Outpost$/i }))
-
     expect(screen.getByRole('button', { name: /Reroll \(0¢\)/i })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: /Build Interceptor \(2🧱 \+ 1¢\)/i })).toBeInTheDocument()
   })
+
+  it('Faction config exposes starting frame and capacity', () => {
+    const warmongers = getFaction('warmongers')
+    expect(warmongers.config.startingFrame).toBe('cruiser')
+    expect(warmongers.config.capacity).toBeGreaterThan(10)
+  })
 })
-
-

--- a/src/config/factions.ts
+++ b/src/config/factions.ts
@@ -1,6 +1,5 @@
-import { type Research, type Resources } from './defaults'
-import { type FrameId } from './frames'
 import { PARTS, type Part } from './parts'
+import { buildFactionConfig, type GameConfig } from './game'
 
 export type FactionId = 'scientists' | 'warmongers' | 'industrialists' | 'raiders';
 
@@ -8,18 +7,7 @@ export type Faction = {
   id: FactionId;
   name: string;
   description: string;
-  // Optional starting overrides
-  startingFrame?: FrameId; // e.g., start with a cruiser
-  startingBlueprintOverrides?: Partial<Record<FrameId, Part[]>>; // swap class blueprints
-  startingResearchDelta?: Partial<Research>; // add to initial research
-  startingResourcesDelta?: Partial<Resources>; // add resources
-  startingCapacityDelta?: number; // add to initial dock capacity
-  startingShopItemsDelta?: number; // influence shop size
-  economy?: {
-    rerollBase?: number;
-    creditMultiplier?: number;
-    materialMultiplier?: number;
-  };
+  config: GameConfig;
 };
 
 export const FACTIONS: readonly Faction[] = [
@@ -27,31 +15,38 @@ export const FACTIONS: readonly Faction[] = [
     id: 'scientists',
     name: 'Consortium of Scholars',
     description: 'All tech tracks start at Tier 2. Better shop quality early.',
-    startingResearchDelta: { Military: 1, Grid: 1, Nano: 1 },
+    config: buildFactionConfig({
+      research: { Military: 2, Grid: 2, Nano: 2 },
+    }),
   },
   {
     id: 'warmongers',
     name: 'Crimson Vanguard',
     description: 'Begin with a Cruiser-class hull blueprint, one Cruiser deployed, and +2 dock capacity.',
-    startingFrame: 'cruiser',
-    startingCapacityDelta: 3,
-    startingResearchDelta: { Military: 1 },
+    config: buildFactionConfig({
+      startingFrame: 'cruiser',
+      capacity: 14,
+      research: { Military: 2 },
+    }),
   },
   {
     id: 'industrialists',
     name: 'Helios Cartel',
     description: '+10¢ +3🧱 to jumpstart the economy; rerolls free initially and actions cost less.',
-    startingResourcesDelta: { credits: 10, materials: 3 },
-    startingShopItemsDelta: 0,
-    economy: { rerollBase: 0, creditMultiplier: 0.75, materialMultiplier: 0.75 },
+    config: buildFactionConfig({
+      resources: { credits: 20, materials: 8 },
+      economy: { rerollBase: 0, creditMultiplier: 0.75, materialMultiplier: 0.75 },
+    }),
   },
   {
     id: 'raiders',
     name: 'Void Corsairs',
     description: 'Interceptors start with Tier 2 cannon and +1 initiative (better drives).',
-    startingBlueprintOverrides: {
-      interceptor: [PARTS.sources[1], PARTS.drives[1], PARTS.weapons[1], PARTS.computers[0]],
-    },
+    config: buildFactionConfig({
+      blueprints: {
+        interceptor: [PARTS.sources[1], PARTS.drives[1], PARTS.weapons[1], PARTS.computers[0]] as Part[],
+      },
+    }),
   },
 ];
 
@@ -113,5 +108,4 @@ export function getBossFleetFor(fid: FactionId|undefined|null, sector:number){
   const def = BOSS_FLEETS[id];
   return sector>=10 ? def.ten : def.five;
 }
-
 

--- a/src/config/game.ts
+++ b/src/config/game.ts
@@ -1,0 +1,75 @@
+import { type Research, type Resources, INITIAL_RESEARCH, INITIAL_RESOURCES, INITIAL_BLUEPRINTS, INITIAL_CAPACITY } from './defaults'
+import { type FrameId } from './frames'
+import { type Part } from './parts'
+import { ECONOMY } from './economy'
+
+export type GameEconomy = {
+  rerollBase?: number;
+  creditMultiplier?: number;
+  materialMultiplier?: number;
+};
+
+export type GameConfig = {
+  research: Research;
+  resources: Resources;
+  blueprints: Record<FrameId, Part[]>;
+  startingFrame: FrameId;
+  capacity: number;
+  shopSize: number;
+  economy: GameEconomy;
+};
+
+export const BASE_CONFIG: GameConfig = {
+  research: { ...INITIAL_RESEARCH },
+  resources: { ...INITIAL_RESOURCES },
+  blueprints: {
+    interceptor: [ ...INITIAL_BLUEPRINTS.interceptor ],
+    cruiser: [ ...INITIAL_BLUEPRINTS.cruiser ],
+    dread: [ ...INITIAL_BLUEPRINTS.dread ],
+  },
+  startingFrame: 'interceptor',
+  capacity: INITIAL_CAPACITY.cap,
+  shopSize: ECONOMY.shop.itemsBase,
+  economy: {},
+};
+
+export type GameConfigOverrides = {
+  research?: Partial<Research>;
+  resources?: Partial<Resources>;
+  blueprints?: Partial<Record<FrameId, Part[]>>;
+  startingFrame?: FrameId;
+  capacity?: number;
+  shopSize?: number;
+  economy?: GameEconomy;
+};
+
+export function buildFactionConfig(overrides: GameConfigOverrides): GameConfig {
+  return {
+    research: { ...BASE_CONFIG.research, ...(overrides.research || {}) },
+    resources: { ...BASE_CONFIG.resources, ...(overrides.resources || {}) },
+    blueprints: {
+      interceptor: [
+        ...(overrides.blueprints?.interceptor || BASE_CONFIG.blueprints.interceptor),
+      ],
+      cruiser: [
+        ...(overrides.blueprints?.cruiser || BASE_CONFIG.blueprints.cruiser),
+      ],
+      dread: [ ...(overrides.blueprints?.dread || BASE_CONFIG.blueprints.dread) ],
+    },
+    startingFrame: overrides.startingFrame ?? BASE_CONFIG.startingFrame,
+    capacity: overrides.capacity ?? BASE_CONFIG.capacity,
+    shopSize: overrides.shopSize ?? BASE_CONFIG.shopSize,
+    economy: {
+      rerollBase: overrides.economy?.rerollBase ?? BASE_CONFIG.economy.rerollBase,
+      creditMultiplier:
+        overrides.economy?.creditMultiplier ??
+        BASE_CONFIG.economy.creditMultiplier ??
+        1,
+      materialMultiplier:
+        overrides.economy?.materialMultiplier ??
+        BASE_CONFIG.economy.materialMultiplier ??
+        1,
+    },
+  };
+}
+

--- a/src/game/setup.ts
+++ b/src/game/setup.ts
@@ -1,9 +1,8 @@
-import { type Research, type Resources, INITIAL_BLUEPRINTS, INITIAL_RESEARCH, INITIAL_RESOURCES, INITIAL_CAPACITY } from '../config/defaults'
+import { type Research, type Resources } from '../config/defaults'
 import { type FrameId } from '../config/frames'
 import { getFaction, type FactionId } from '../config/factions'
 import { type Part } from '../config/parts'
 import { getFrame, makeShip, rollInventory, setPlayerFaction, pickOpponentFaction, setEconomyModifiers } from './index'
-import { ECONOMY } from '../config/economy'
 import { getStartingShipCount, getBaseRerollCost, getInitialCapacityForDifficulty } from '../config/difficulty'
 import { type DifficultyId } from '../config/types'
 
@@ -23,46 +22,30 @@ export function initNewRun({ difficulty, faction }: NewRunParams): NewRunState{
   const f = getFaction(faction);
   setPlayerFaction(f.id);
   pickOpponentFaction();
-  const creditMult = f.economy?.creditMultiplier ?? 1;
-  const materialMult = f.economy?.materialMultiplier ?? 1;
+  const creditMult = f.config.economy.creditMultiplier ?? 1;
+  const materialMult = f.config.economy.materialMultiplier ?? 1;
   setEconomyModifiers({ credits: creditMult, materials: materialMult });
-  const baseRes = { ...INITIAL_RESOURCES };
-  const baseTech = { ...INITIAL_RESEARCH };
-  const res: Resources = {
-    credits: baseRes.credits + (f.startingResourcesDelta?.credits||0),
-    materials: baseRes.materials + (f.startingResourcesDelta?.materials||0),
-    science: baseRes.science + (f.startingResourcesDelta?.science||0),
-  };
-  const research: Research = {
-    Military: baseTech.Military + (f.startingResearchDelta?.Military||0),
-    Grid: baseTech.Grid + (f.startingResearchDelta?.Grid||0),
-    Nano: baseTech.Nano + (f.startingResearchDelta?.Nano||0),
-  } as Research;
+
+  const res: Resources = { ...f.config.resources };
+  const research: Research = { ...f.config.research } as Research;
 
   const classBlueprints: Record<FrameId, Part[]> = {
-    interceptor: [ ...INITIAL_BLUEPRINTS.interceptor ],
-    cruiser: [ ...INITIAL_BLUEPRINTS.cruiser ],
-    dread: [ ...INITIAL_BLUEPRINTS.dread ],
+    interceptor: [ ...f.config.blueprints.interceptor ],
+    cruiser: [ ...f.config.blueprints.cruiser ],
+    dread: [ ...f.config.blueprints.dread ],
   };
-  if(f.startingBlueprintOverrides){
-    for(const k of Object.keys(f.startingBlueprintOverrides) as FrameId[]){
-      const ov = f.startingBlueprintOverrides[k];
-      if(ov && ov.length>0) classBlueprints[k] = [...ov];
-    }
-  }
 
-  const startFrameId = (f.startingFrame || 'interceptor') as FrameId;
+  const startFrameId = f.config.startingFrame as FrameId;
   const count = getStartingShipCount(difficulty);
   const fleet = Array.from({length: count}, ()=> makeShip(getFrame(startFrameId), [ ...classBlueprints[startFrameId] ]));
 
-  const shopItems = rollInventory(research, ECONOMY.shop.itemsBase + (f.startingShopItemsDelta||0));
+  const shopItems = rollInventory(research, f.config.shopSize);
 
-  const baseCap = getInitialCapacityForDifficulty(difficulty, (f.startingFrame||'interceptor') as FrameId);
-  const capacity = { cap: Math.max(baseCap, INITIAL_CAPACITY.cap + (f.startingCapacityDelta||0)) };
+  const baseCap = getInitialCapacityForDifficulty(difficulty, startFrameId);
+  const capacity = { cap: Math.max(baseCap, f.config.capacity) };
 
-  const baseReroll = f.economy?.rerollBase ?? getBaseRerollCost(difficulty);
+  const baseReroll = f.config.economy.rerollBase ?? getBaseRerollCost(difficulty);
   const rerollCost = Math.max(0, Math.floor(baseReroll * creditMult));
   return { resources: res, research, rerollCost, sector: 1, blueprints: classBlueprints, fleet, shopItems, capacity };
 }
-
 


### PR DESCRIPTION
## Summary
- Add `GameConfig` and builder to define run settings per faction
- Rewrite faction data to supply complete configs with research, resources, capacity and more
- Initialize new runs from faction-provided config and add test coverage for config exposure
- Allow partial faction overrides in `buildFactionConfig` and document test/build requirements

## Testing
- `npm test --silent -- --run`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b358ef5dd483338181248bdc8bbe3b