### PR TITLE
Allow installing unpowered parts with warning

### DIFF
--- a/src/__tests__/blueprints.spec.ts
+++ b/src/__tests__/blueprints.spec.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest'
+import { PARTS } from '../config/parts'
+import { getFrame, makeShip } from '../game'
+import { canInstallOnClass, updateBlueprint } from '../game/blueprints'
+import type { FrameId } from '../config/frames'
+
+describe('blueprint install rules', () => {
+  it('allows installing parts that exceed power but marks ship invalid', () => {
+    const frameId: FrameId = 'interceptor'
+    const blueprints = { interceptor: [PARTS.sources[0], PARTS.drives[0]], cruiser: [], dread: [] }
+    const chk = canInstallOnClass(blueprints, frameId, PARTS.weapons[2])
+    expect(chk.ok).toBe(true)
+    expect(chk.tmp.stats.valid).toBe(false)
+    const res = updateBlueprint(blueprints, frameId, arr => [...arr, PARTS.weapons[2]], true)
+    expect(res.updated).toBe(true)
+    const ship = makeShip(getFrame(frameId), res.blueprints[frameId])
+    expect(ship.stats.valid).toBe(false)
+  })
+
+  it('rejects parts when tile capacity would be exceeded', () => {
+    const frameId: FrameId = 'interceptor'
+    const frame = getFrame(frameId)
+    const parts = Array(frame.tiles).fill(PARTS.sources[0])
+    const blueprints = { interceptor: parts, cruiser: [], dread: [] }
+    const chk = canInstallOnClass(blueprints, frameId, PARTS.sources[0])
+    expect(chk.ok).toBe(false)
+  })
+})
+

--- a/src/game/blueprints.ts
+++ b/src/game/blueprints.ts
@@ -8,19 +8,23 @@ export function applyBlueprintToFleet(frameId:FrameId, parts:Part[], fleet:Ship[
 }
 
 export function canInstallOnClass(blueprints:Record<FrameId, Part[]>, frameId:FrameId, part:Part){
-  const tmp = makeShip(getFrame(frameId), [...blueprints[frameId], part]);
-  return { ok: tmp.stats.valid, tmp };
+  const frame = getFrame(frameId);
+  const nextParts = [...blueprints[frameId], part];
+  const tmp = makeShip(frame, nextParts);
+  const tilesOk = nextParts.length <= frame.tiles;
+  return { ok: tilesOk, tmp };
 }
 
 export function updateBlueprint(
   blueprints:Record<FrameId, Part[]>,
   frameId:FrameId,
-  mutate:(arr:Part[])=>Part[]
+  mutate:(arr:Part[])=>Part[],
+  allowInvalid:boolean = false
 ){
   const next = { ...blueprints } as Record<FrameId,Part[]>;
   const after = mutate(next[frameId]);
   const tmp = makeShip(getFrame(frameId), after);
-  if(!tmp.stats.valid) return { blueprints, updated:false } as const;
+  if(!allowInvalid && !tmp.stats.valid) return { blueprints, updated:false } as const;
   next[frameId] = after;
   return { blueprints: next, updated:true } as const;
 }


### PR DESCRIPTION
## Summary
- allow parts to be installed even if power is insufficient, warning that ship can't fight
- block purchases that exceed tile capacity
- cover unpowered installs with tests

## Testing
- `npm run test:run`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b360a400a08333bc1917fd024a44d4