### PR TITLE
feat: add endless mode after sector 10

### DIFF
--- a/src/__tests__/rewards.spec.ts
+++ b/src/__tests__/rewards.spec.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from 'vitest'
+import { calcRewards } from '../game/rewards'
+import { makeShip, getFrame } from '../game'
+import { PARTS } from '../config/parts'
+
+describe('rewards', () => {
+  it('treats every fifth sector as a boss', () => {
+    const enemy = [makeShip(getFrame('interceptor'), [PARTS.sources[0], PARTS.drives[0]])] as any
+    const normal = calcRewards(enemy, 16)
+    const boss = calcRewards(enemy, 15)
+    expect(boss.s).toBe(normal.s + 1)
+    expect(boss.m).toBe(normal.m + 1)
+  })
+})

--- a/src/__tests__/winmodal.spec.tsx
+++ b/src/__tests__/winmodal.spec.tsx
@@ -1,0 +1,14 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { WinModal } from '../components/modals'
+
+describe('WinModal', () => {
+  it('provides an endless war option', () => {
+    const onRestart = vi.fn()
+    const onEndless = vi.fn()
+    render(<WinModal onRestart={onRestart} onEndless={onEndless} />)
+    const btn = screen.getByRole('button', { name: /Endless War/i })
+    fireEvent.click(btn)
+    expect(onEndless).toHaveBeenCalled()
+  })
+})

--- a/src/components/modals.tsx
+++ b/src/components/modals.tsx
@@ -235,13 +235,16 @@ export function TechListModal({ onClose, research }:{ onClose:()=>void, research
   );
 }
 
-export function WinModal({ onRestart }:{ onRestart:()=>void }){
+export function WinModal({ onRestart, onEndless }:{ onRestart:()=>void; onEndless:()=>void }){
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center p-3 bg-black/70">
       <div className="w-full max-w-md bg-zinc-900 border border-zinc-700 rounded-2xl p-6 text-center">
         <div className="text-2xl font-bold mb-2">You Win!</div>
         <div className="text-sm mb-4">Sector 10 cleared. Congratulations!</div>
-        <button onClick={onRestart} className="px-4 py-2 rounded-xl bg-emerald-600">Restart Run</button>
+        <div className="flex flex-col gap-2">
+          <button onClick={onRestart} className="px-4 py-2 rounded-xl bg-emerald-600">Restart Run</button>
+          <button onClick={onEndless} className="px-4 py-2 rounded-xl bg-sky-600">Endless War</button>
+        </div>
       </div>
     </div>
   );

--- a/src/game/rewards.ts
+++ b/src/game/rewards.ts
@@ -5,7 +5,15 @@ import { type FrameId } from '../config/frames'
 import { type Part } from '../config/parts'
 import { type Resources } from '../config/defaults'
 
-export function calcRewards(enemy:Ship[], sector:number){ let c=0,m=0,s=0; enemy.forEach(sh=>{ if(!sh) return; const rw = calcRewardsForFrameId(sh.frame.id); c+=rw.c; m+=rw.m; s+=rw.s; }); const boss = (sector===5 || sector===10); const mult = 1 + Math.floor(Math.max(0, sector-1))*0.06; c = Math.floor(c*mult * (boss?1.25:1)); if(boss){ s += 1; m += 1; } return { c, m, s }; }
+export function calcRewards(enemy:Ship[], sector:number){
+  let c=0,m=0,s=0;
+  enemy.forEach(sh=>{ if(!sh) return; const rw = calcRewardsForFrameId(sh.frame.id); c+=rw.c; m+=rw.m; s+=rw.s; });
+  const boss = sector % 5 === 0;
+  const mult = 1 + Math.floor(Math.max(0, sector-1))*0.06;
+  c = Math.floor(c*mult * (boss?1.25:1));
+  if(boss){ s += 1; m += 1; }
+  return { c, m, s };
+}
 
 export function graceRecoverFleet(blueprints:Record<FrameId, Part[]>): Ship[]{
   return [ makeShip(getFrame('interceptor'), [ ...blueprints.interceptor ]) ] as unknown as Ship[];


### PR DESCRIPTION
## Summary
- add optional Endless War continuation after clearing sector 10
- scale rewards and bosses every 5 sectors in endless mode
- record grace usage so runs reset after a final defeat

## Testing
- `npx vitest run --reporter=dot`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b368ec9cc083338d0c8c1821486771