### PR TITLE
Fix dock expansion, mobile overlay, and auto victory

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -206,20 +206,20 @@ export default function EclipseIntegrated(){
     setRoundNum(1); setQueue([]); setTurnPtr(-1); setAuto(false); setCombatOver(false); setOutcome(''); setRewardPaid(false); setMode('COMBAT');
   }
   function initRoundIfNeeded(){ if (turnPtr === -1 || turnPtr >= queue.length) { const q = buildInitiative(fleet, enemyFleet); setQueue(q); setTurnPtr(0); setLog(l => [...l, `— Round ${roundNum} —`]); return true; } return false; }
-  function stepTurn(){ if(combatOver) return; const pAlive = fleet.some(s => s.alive && s.stats.valid); const eAlive = enemyFleet.some(s => s.alive && s.stats.valid); if (!pAlive || !eAlive) {
-      if(pAlive){
-        if(!rewardPaid){ const rw = calcRewards(enemyFleet, sector); setResources(r=>({...r, credits: r.credits + rw.c, materials: r.materials + rw.m, science: r.science + rw.s })); setRewardPaid(true); setLog(l=>[...l, `✅ Victory — +${rw.c}¢, +${rw.m}🧱, +${rw.s}🔬`]); }
-        setOutcome('Victory'); setSector(s=> s+1); setRerollCost(baseRerollCost);
-      }
-      else {
-        if(difficulty && (getDefeatPolicy(difficulty)==='reset' || graceUsed)) { setOutcome('Defeat — Run Over'); }
-        else { setOutcome('Defeat — Grace'); setGraceUsed(true); }
-        setLog(l=>[...l, '💀 Defeat']);
-      }
-      setCombatOver(true); setAuto(false); return; }
-    if (initRoundIfNeeded()) return; const e = queue[turnPtr]; const isP = e.side==='P'; const atk = isP ? fleet[e.idx] : enemyFleet[e.idx]; const defFleet = isP ? enemyFleet : fleet; const strategy = isP ? 'guns' : 'kill'; const defIdx = targetIndex(defFleet, strategy); if (!atk || !atk.alive || !atk.stats.valid || defIdx === -1) { advancePtr(); return; } const lines:string[] = []; volley(atk, defFleet[defIdx], e.side, lines); setLog(l=>[...l, ...lines]); if (isP) setEnemyFleet([...defFleet]); else setFleet([...defFleet]); advancePtr(); }
+  function resolveCombat(pAlive:boolean){
+    if(pAlive){
+      if(!rewardPaid){ const rw = calcRewards(enemyFleet, sector); setResources(r=>({...r, credits: r.credits + rw.c, materials: r.materials + rw.m, science: r.science + rw.s })); setRewardPaid(true); setLog(l=>[...l, `✅ Victory — +${rw.c}¢, +${rw.m}🧱, +${rw.s}🔬`]); }
+      setOutcome('Victory'); setSector(s=> s+1); setRerollCost(baseRerollCost);
+    } else {
+      if(difficulty && (getDefeatPolicy(difficulty)==='reset' || graceUsed)) { setOutcome('Defeat — Run Over'); }
+      else { setOutcome('Defeat — Grace'); setGraceUsed(true); }
+      setLog(l=>[...l, '💀 Defeat']);
+    }
+    setCombatOver(true); setAuto(false);
+  }
+  function stepTurn(){ if(combatOver) return; const pAlive = fleet.some(s => s.alive && s.stats.valid); const eAlive = enemyFleet.some(s => s.alive && s.stats.valid); if (!pAlive || !eAlive) { resolveCombat(pAlive); return; } if (initRoundIfNeeded()) return; const e = queue[turnPtr]; const isP = e.side==='P'; const atk = isP ? fleet[e.idx] : enemyFleet[e.idx]; const defFleet = isP ? enemyFleet : fleet; const strategy = isP ? 'guns' : 'kill'; const defIdx = targetIndex(defFleet, strategy); if (!atk || !atk.alive || !atk.stats.valid || defIdx === -1) { advancePtr(); return; } const lines:string[] = []; volley(atk, defFleet[defIdx], e.side, lines); setLog(l=>[...l, ...lines]); if (isP) setEnemyFleet([...defFleet]); else setFleet([...defFleet]); advancePtr(); }
   function advancePtr(){ const np = turnPtr + 1; setTurnPtr(np); if (np >= queue.length) endRound(); }
-  function endRound(){ const pAlive = fleet.some(s => s.alive && s.stats.valid); const eAlive = enemyFleet.some(s => s.alive && s.stats.valid); if (!pAlive || !eAlive) { setAuto(false); return; } setRoundNum(n=>n+1); setTurnPtr(-1); setQueue([]); }
+  function endRound(){ const pAlive = fleet.some(s => s.alive && s.stats.valid); const eAlive = enemyFleet.some(s => s.alive && s.stats.valid); if (!pAlive || !eAlive) { resolveCombat(pAlive); return; } setRoundNum(n=>n+1); setTurnPtr(-1); setQueue([]); }
   function restoreAndCullFleetAfterCombat(){ setFleet(f => f.filter(s => s.alive).map(s => ({...s, hull: s.stats.hullCap}))); setFocused(0); }
 
   // Auto-step loop

--- a/src/__tests__/auto.victory.spec.tsx
+++ b/src/__tests__/auto.victory.spec.tsx
@@ -1,0 +1,12 @@
+import { describe, it } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import App from '../App'
+
+describe('auto combat', () => {
+  it('reaches victory without extra manual step', async () => {
+    render(<App />)
+    fireEvent.click(screen.getByRole('button', { name: /Easy/i }))
+    fireEvent.click(screen.getByRole('button', { name: /Auto/i }))
+    await screen.findByText(/Victory/i, undefined, { timeout: 10000 })
+  })
+})

--- a/src/__tests__/hangar.spec.ts
+++ b/src/__tests__/hangar.spec.ts
@@ -1,0 +1,11 @@
+import { describe, it, expect } from 'vitest'
+import { expandDock } from '../game/hangar'
+import { ECONOMY } from '../config/economy'
+
+describe('dock expansion', () => {
+  it('cannot expand beyond capacity max', () => {
+    const cap = ECONOMY.dockUpgrade.capacityMax
+    const result = expandDock({ credits: 100, materials: 100 }, { cap })
+    expect(result).toBeNull()
+  })
+})

--- a/src/game/hangar.ts
+++ b/src/game/hangar.ts
@@ -56,6 +56,7 @@ export function expandDock(resources:{credits:number, materials:number}, capacit
     c: Math.max(1, Math.floor(base.credits * mod.credits)),
     m: Math.max(1, Math.floor(base.materials * mod.materials)),
   };
+  if(capacity.cap >= base.capacityMax) return null;
   if(resources.credits < cost.c || resources.materials < cost.m) return null;
   const nextCap = Math.min(base.capacityMax, capacity.cap + base.capacityDelta);
   return { nextCap, delta:{ credits: -cost.c, materials: -cost.m } };

--- a/src/pages/OutpostPage.tsx
+++ b/src/pages/OutpostPage.tsx
@@ -70,6 +70,7 @@ export function OutpostPage({
     materials: Math.max(1, Math.floor(ECONOMY.dockUpgrade.materials * econ.materials)),
     credits: Math.max(1, Math.floor(ECONOMY.dockUpgrade.credits * econ.credits)),
   };
+  const dockAtCap = capacity.cap >= ECONOMY.dockUpgrade.capacityMax;
   const rrInc = Math.max(1, Math.floor(ECONOMY.reroll.increment * econ.credits));
   const nextUpgrade = (()=>{
     if(!focusedShip) return null;
@@ -109,8 +110,10 @@ export function OutpostPage({
     return '';
   }
   return (
-    <div className="mx-auto max-w-5xl">
+    <>
       {showPlan && <CombatPlanModal onClose={()=>setShowPlan(false)} />}
+
+      <div className="mx-auto max-w-5xl pb-24">
 
       {/* Hangar */}
       <div className="p-3">
@@ -140,7 +143,7 @@ export function OutpostPage({
           </div>
         ); })()}
         <div className="mt-2 grid grid-cols-2 gap-2">
-          <button onClick={upgradeDock} className="px-3 py-3 rounded-xl bg-indigo-600 hover:bg-indigo-500 active:scale-95">Expand Capacity +{ECONOMY.dockUpgrade.capacityDelta} ({dockCost.materials}🧱 + {dockCost.credits}¢)</button>
+          <button onClick={upgradeDock} disabled={dockAtCap} className={`px-3 py-3 rounded-xl ${dockAtCap? 'bg-zinc-700 opacity-60' : 'bg-indigo-600 hover:bg-indigo-500 active:scale-95'}`}>{dockAtCap ? 'Capacity Maxed' : `Expand Capacity +${ECONOMY.dockUpgrade.capacityDelta} (${dockCost.materials}🧱 + ${dockCost.credits}¢)`}</button>
           <div className="px-3 py-3 rounded-xl bg-zinc-900 border border-zinc-700 text-sm">Capacity: <b>{capacity.cap}</b> • Used: <b>{tonnage.used}</b></div>
         </div>
 
@@ -214,17 +217,18 @@ export function OutpostPage({
           </div>
         </div>
       </div>
-      
+      </div>
+
 
       {/* Start Combat */}
-      <div className="sticky bottom-0 z-10 p-3 bg-zinc-950/95 backdrop-blur border-t border-zinc-800">
+      <div className="fixed bottom-0 left-0 w-full z-10 p-3 bg-zinc-950/95 backdrop-blur border-t border-zinc-800">
         <div className="mx-auto max-w-5xl flex items-center gap-2">
           <button onClick={()=> fleetValid && startCombat()} className={`flex-1 px-4 py-3 rounded-xl ${fleetValid?'bg-emerald-600':'bg-zinc-700 opacity-60'}`}>Start Combat</button>
           {!fleet.every(s=>s.stats.valid) && <div className="text-xs text-rose-300">Fix fleet (Source + Drive + ⚡ OK)</div>}
           {tonnage.used > capacity.cap && <div className="text-xs text-rose-300">Over capacity — expand docks</div>}
         </div>
       </div>
-    </div>
+    </>
   )
 }
 


### PR DESCRIPTION
## Summary
- prevent dock expansion past capacity max and disable button when maxed
- anchor start combat bar to viewport bottom to avoid covering content
- ensure auto combat resolves victory without manual step

## Testing
- `npm run test:run`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b3841667fc83339a3bb14468329520