### PR TITLE
feat: generalize weapon dice faces

### DIFF
--- a/src/__tests__/dice.spec.ts
+++ b/src/__tests__/dice.spec.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest'
+import { makeShip, getFrame, PARTS } from '../game'
+import { volley } from '../game/combat'
+
+describe('weapon dice faces', () => {
+  it('standard die uses weapon-specific damage face', () => {
+    const src = PARTS.sources[0]
+    const drv = PARTS.drives[0]
+    const antimatter = PARTS.weapons.find(p=>p.id==='antimatter')!
+    const hullp = PARTS.hull.find(p=>p.id==='improved')!
+    const attacker = makeShip(getFrame('interceptor'), [src, drv, antimatter])
+    const defender = makeShip(getFrame('interceptor'), [src, drv, hullp])
+    const seq = [0.95]
+    const orig = Math.random
+    Math.random = () => seq.shift()!
+    volley(attacker, defender, 'P', [], [attacker])
+    Math.random = orig
+    expect(defender.hull).toBe(defender.stats.hullCap - antimatter.dmgPerHit!)
+  })
+
+  it('spike launcher deals big damage on spike face', () => {
+    const src = PARTS.sources[0]
+    const drv = PARTS.drives[0]
+    const spike = PARTS.weapons.find(p=>p.id==='spike_launcher')!
+    const hullp = PARTS.hull.find(p=>p.id==='improved')!
+    const attacker = makeShip(getFrame('interceptor'), [src, drv, spike])
+    const defender = makeShip(getFrame('interceptor'), [src, drv, hullp])
+    const seq = [0.95]
+    const orig = Math.random
+    Math.random = () => seq.shift()!
+    volley(attacker, defender, 'P', [], [attacker])
+    Math.random = orig
+    expect(defender.hull).toBe(defender.stats.hullCap - 3)
+  })
+})

--- a/src/__tests__/effects.spec.ts
+++ b/src/__tests__/effects.spec.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest'
+import { PARTS, partEffects } from '../config/parts'
+
+describe('partEffects display', () => {
+  it('shows spike launcher max damage and hit chance', () => {
+    const spike = PARTS.weapons.find(p=>p.id==='spike_launcher')!
+    const eff = partEffects(spike)
+    expect(eff).toContain('💥3')
+    expect(eff).toContain('🎯17%')
+  })
+
+  it('shows standard cannon damage and hit chance', () => {
+    const plasma = PARTS.weapons.find(p=>p.id==='plasma')!
+    const eff = partEffects(plasma)
+    expect(eff).toContain('💥1')
+    expect(eff).toContain('🎯17%')
+  })
+})

--- a/src/__tests__/rift.spec.ts
+++ b/src/__tests__/rift.spec.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest'
+import { makeShip, getFrame, PARTS } from '../game'
+import { volley } from '../game/combat'
+
+describe('rift weapons', () => {
+  it('assigns self-damage to largest killable rift ship', () => {
+    const src = PARTS.sources[0]
+    const drv = PARTS.drives[0]
+    const rift = PARTS.weapons.find(p=>p.id==='rift_cannon')!
+    const attacker = makeShip(getFrame('interceptor'), [src, drv, rift])
+    const ally = makeShip(getFrame('dread'), [src, drv, rift])
+    const defender = makeShip(getFrame('interceptor'), [src, drv])
+    const seq = [0.5] // face 4 -> self-damage only
+    const orig = Math.random
+    Math.random = () => seq.shift()!
+    volley(attacker, defender, 'P', [], [attacker, ally])
+    Math.random = orig
+    expect(ally.alive).toBe(false)
+    expect(attacker.alive).toBe(true)
+  })
+
+  it('rift conductor grants extra rift die', () => {
+    const src = PARTS.sources[0]
+    const drv = PARTS.drives[0]
+    const rift = PARTS.weapons.find(p=>p.id==='rift_cannon')!
+    const conductor = PARTS.hull.find(p=>p.id==='rift_conductor')!
+    const attacker = makeShip(getFrame('interceptor'), [src, drv, rift, conductor])
+    const defender = makeShip(getFrame('interceptor'), [src, drv])
+    const seq = [0, 0.2] // faces 1 and 2 -> total 3 dmg
+    const orig = Math.random
+    Math.random = () => seq.shift()!
+    volley(attacker, defender, 'P', [], [attacker])
+    Math.random = orig
+    expect(defender.alive).toBe(false)
+    expect(attacker.alive).toBe(true)
+  })
+})
+

--- a/src/components/ui.tsx
+++ b/src/components/ui.tsx
@@ -30,11 +30,14 @@ export function CompactShip({ ship, side, active }:{ship:Ship, side:'P'|'E', act
       <HullPips current={Math.max(0, ship.hull)} max={ship.stats.hullCap} />
       {/* Dice/Damage summary per weapon */}
       <div className="mt-1 flex flex-wrap gap-1 min-h-[18px]">
-        {ship.weapons.length>0 ? ship.weapons.map((w:Part, i:number)=> (
-          <span key={i} className="px-1.5 py-0.5 rounded bg-zinc-800 border border-zinc-700 text-[10px] whitespace-nowrap">
-            {w.dice||0}🎲 × {w.dmgPerHit||0}
-          </span>
-        )) : (
+        {ship.weapons.length>0 ? ship.weapons.map((w:Part, i:number)=> {
+          const maxDmg = Math.max(w.dmgPerHit||0, ...(w.faces||[]).map(f=>f.dmg||0));
+          return (
+            <span key={i} className="px-1.5 py-0.5 rounded bg-zinc-800 border border-zinc-700 text-[10px] whitespace-nowrap">
+              {w.dice||0}🎲 × {maxDmg}
+            </span>
+          );
+        }) : (
           <span className="text-[10px] opacity-60">No weapons</span>
         )}
       </div>

--- a/src/config/parts.ts
+++ b/src/config/parts.ts
@@ -230,10 +230,25 @@ export const PART_EFFECT_SYMBOLS: Record<PartEffectField, string> = {
 export function partEffects(p: Part) {
   const effects: string[] = [];
   for (const key of PART_EFFECT_FIELDS) {
+    if (key === 'dmgPerHit') continue;
     const val = p[key as keyof Part];
     if (typeof val === 'number' && val !== 0) {
       effects.push(`${PART_EFFECT_SYMBOLS[key]}${val}`);
     }
+  }
+  if (p.cat === 'Weapon') {
+    const faces = p.faces || [];
+    const maxDmg = Math.max(p.dmgPerHit || 0, ...faces.map(f => f.dmg || 0));
+    if (maxDmg > 0) effects.push(`${PART_EFFECT_SYMBOLS.dmgPerHit}${maxDmg}`);
+    if (faces.length > 0) {
+      const hitFaces = faces.filter(f => f.dmg).length;
+      if (hitFaces > 0) {
+        const pct = Math.round((hitFaces / faces.length) * 100);
+        effects.push(`🎯${pct}%`);
+      }
+    }
+  } else if (typeof p.dmgPerHit === 'number' && p.dmgPerHit !== 0) {
+    effects.push(`${PART_EFFECT_SYMBOLS.dmgPerHit}${p.dmgPerHit}`);
   }
   return effects;
 }

--- a/src/config/parts.ts
+++ b/src/config/parts.ts
@@ -1,6 +1,12 @@
 export type TechTrack = 'Military' | 'Grid' | 'Nano';
 export type PartCategory = 'Source' | 'Drive' | 'Weapon' | 'Computer' | 'Shield' | 'Hull';
 
+export type DieFace = {
+  roll?: number;
+  dmg?: number;
+  self?: number;
+};
+
 export type Part = {
   id: string;
   name: string;
@@ -9,6 +15,8 @@ export type Part = {
   init?: number;
   dice?: number;
   dmgPerHit?: number;
+  riftDice?: number;
+  faces?: DieFace[];
   shieldTier?: number;
   extraHull?: number;
   aim?: number;
@@ -27,6 +35,15 @@ export type PartCatalog = {
   hull: Part[];
 }
 
+export const RIFT_FACES: DieFace[] = [
+  { dmg: 1 },
+  { dmg: 2 },
+  { dmg: 3, self: 1 },
+  { self: 1 },
+  {},
+  {},
+] as const;
+
 export const PARTS: PartCatalog = {
   sources: [
     { id: "fusion_source", name: "Fusion Source", powerProd: 3, tier: 1, cost: 18, cat: "Source", tech_category: "Grid" },
@@ -44,11 +61,112 @@ export const PARTS: PartCatalog = {
     { id: "transition_drive", name: "Transition Drive", init: 3, powerCost: 2, tier: 3, cost: 120, cat: "Drive", tech_category: "Grid" },
   ],
   weapons: [
-    { id: "plasma", name: "Plasma Cannon", dice: 1, dmgPerHit: 1, powerCost: 1, tier: 1, cost: 25, cat: "Weapon", tech_category: "Nano" },
-    { id: "antimatter", name: "Antimatter Cannon", dice: 1, dmgPerHit: 2, powerCost: 2, tier: 2, cost: 75, cat: "Weapon", tech_category: "Nano" },
-    { id: "singularity", name: "Singularity Launcher", dice: 1, dmgPerHit: 3, powerCost: 3, tier: 3, cost: 120, cat: "Weapon", tech_category: "Nano" },
-    { id: "gauss_array", name: "Gauss Array", dice: 2, dmgPerHit: 1, powerCost: 2, tier: 2, cost: 60, cat: "Weapon", tech_category: "Nano" },
-    { id: "rift_cannon", name: "Rift Cannon", dice: 2, dmgPerHit: 2, powerCost: 3, tier: 3, cost: 140, cat: "Weapon", tech_category: "Nano" },
+    {
+      id: "plasma",
+      name: "Plasma Cannon",
+      dice: 1,
+      dmgPerHit: 1,
+      faces: [
+        { roll: 1 },
+        { roll: 2 },
+        { roll: 3 },
+        { roll: 4 },
+        { roll: 5 },
+        { dmg: 1 },
+      ],
+      powerCost: 1,
+      tier: 1,
+      cost: 25,
+      cat: "Weapon",
+      tech_category: "Nano",
+    },
+    {
+      id: "antimatter",
+      name: "Antimatter Cannon",
+      dice: 1,
+      dmgPerHit: 2,
+      faces: [
+        { roll: 1 },
+        { roll: 2 },
+        { roll: 3 },
+        { roll: 4 },
+        { roll: 5 },
+        { dmg: 2 },
+      ],
+      powerCost: 2,
+      tier: 2,
+      cost: 75,
+      cat: "Weapon",
+      tech_category: "Nano",
+    },
+    {
+      id: "singularity",
+      name: "Singularity Launcher",
+      dice: 1,
+      dmgPerHit: 3,
+      faces: [
+        { roll: 1 },
+        { roll: 2 },
+        { roll: 3 },
+        { roll: 4 },
+        { roll: 5 },
+        { dmg: 3 },
+      ],
+      powerCost: 3,
+      tier: 3,
+      cost: 120,
+      cat: "Weapon",
+      tech_category: "Nano",
+    },
+    {
+      id: "gauss_array",
+      name: "Gauss Array",
+      dice: 2,
+      dmgPerHit: 1,
+      faces: [
+        { roll: 1 },
+        { roll: 2 },
+        { roll: 3 },
+        { roll: 4 },
+        { roll: 5 },
+        { dmg: 1 },
+      ],
+      powerCost: 2,
+      tier: 2,
+      cost: 60,
+      cat: "Weapon",
+      tech_category: "Nano",
+    },
+    {
+      id: "spike_launcher",
+      name: "Spike Launcher",
+      dice: 1,
+      dmgPerHit: 1,
+      faces: [
+        { roll: 0 },
+        { roll: 0 },
+        { roll: 0 },
+        { roll: 0 },
+        { roll: 0 },
+        { dmg: 3 },
+      ],
+      powerCost: 1,
+      tier: 1,
+      cost: 30,
+      cat: "Weapon",
+      tech_category: "Nano",
+    },
+    {
+      id: "rift_cannon",
+      name: "Rift Cannon",
+      riftDice: 1,
+      faces: RIFT_FACES,
+      powerCost: 2,
+      tier: 2,
+      cost: 65,
+      cat: "Weapon",
+      tech_category: "Nano",
+    },
   ],
   computers: [
     { id: "positron", name: "Positron Computer", aim: 1, powerCost: 1, tier: 1, cost: 25, cat: "Computer", tech_category: "Grid" },
@@ -70,6 +188,7 @@ export const PARTS: PartCatalog = {
     { id: "adamantine", name: "Adamantine Hull", extraHull: 3, powerCost: 0, tier: 3, cost: 110, cat: "Hull", tech_category: "Nano" },
     { id: "composite", name: "Composite Hull", extraHull: 1, powerCost: 0, tier: 1, cost: 15, cat: "Hull", tech_category: "Nano" },
     { id: "monolith_plating", name: "Monolith Plating", extraHull: 4, powerCost: 0, tier: 3, cost: 160, cat: "Hull", tech_category: "Nano" },
+    { id: "rift_conductor", name: "Rift Conductor", extraHull: 1, riftDice: 1, powerCost: 1, tier: 2, cost: 40, cat: "Hull", tech_category: "Nano" },
   ],
 } as const;
 
@@ -88,6 +207,7 @@ export const PART_EFFECT_FIELDS = [
   'init',
   'dice',
   'dmgPerHit',
+  'riftDice',
   'shieldTier',
   'extraHull',
   'aim',
@@ -101,6 +221,7 @@ export const PART_EFFECT_SYMBOLS: Record<PartEffectField, string> = {
   init: '🚀',
   dice: '🎲',
   dmgPerHit: '💥',
+  riftDice: '🕳️',
   shieldTier: '🛡️',
   extraHull: '❤️',
   aim: '🎯',

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -5,6 +5,7 @@ export type Ship = {
   frame: Frame;
   parts: Part[];
   weapons: Part[];
+  riftDice: number;
   stats: { init: number; hullCap: number; powerUse: number; powerProd: number; valid: boolean; aim: number; shieldTier: number };
   hull: number;
   alive: boolean;

--- a/src/game/combat.ts
+++ b/src/game/combat.ts
@@ -1,74 +1,113 @@
-import { type Part } from '../config/parts'
+import { type Part, RIFT_FACES } from '../config/parts'
 import { type Ship, type InitiativeEntry } from '../config/types'
-import { FRAMES, makeShip, randomEnemyPartsFor, sizeRank, getBossVariantFocus, getOpponentFaction, getBossFleetFor, PARTS } from './index'
+import { FRAMES, makeShip, randomEnemyPartsFor, sizeRank, getBossVariantFocus, getOpponentFaction, getBossFleetFor, PARTS, successThreshold } from './index'
 import { getSectorSpec } from './index'
 
 export function buildInitiative(pFleet:Ship[], eFleet:Ship[]): InitiativeEntry[] {
-  const q:InitiativeEntry[] = [];
-  pFleet.forEach((s, i) => { if (s.alive && s.stats.valid) q.push({ side: 'P', idx: i, init: s.stats.init, size: sizeRank(s.frame) }); });
-  eFleet.forEach((s, i) => { if (s.alive && s.stats.valid) q.push({ side: 'E', idx: i, init: s.stats.init, size: sizeRank(s.frame) }); });
-  q.sort((a, b) => (b.init - a.init) || (b.size - a.size) || (Math.random() - 0.5));
-  return q as InitiativeEntry[];
+  const q:InitiativeEntry[] = []
+  pFleet.forEach((s, i) => { if (s.alive && s.stats.valid) q.push({ side: 'P', idx: i, init: s.stats.init, size: sizeRank(s.frame) }) })
+  eFleet.forEach((s, i) => { if (s.alive && s.stats.valid) q.push({ side: 'E', idx: i, init: s.stats.init, size: sizeRank(s.frame) }) })
+  q.sort((a, b) => (b.init - a.init) || (b.size - a.size) || (Math.random() - 0.5))
+  return q as InitiativeEntry[]
 }
 
 export function targetIndex(defFleet:Ship[], strategy:'kill'|'guns'){
   if(strategy==='kill'){
-    let best=-1, bestHull=1e9; for(let i=0;i<defFleet.length;i++){ const s=defFleet[i]; if(s && s.alive && s.stats.valid){ if(s.hull < bestHull){ bestHull=s.hull; best=i; } } } if(best!==-1) return best;
+    let best=-1, bestHull=1e9
+    for(let i=0;i<defFleet.length;i++){ const s=defFleet[i]; if(s && s.alive && s.stats.valid){ if(s.hull < bestHull){ bestHull=s.hull; best=i } } }
+    if(best!==-1) return best
   }
   if(strategy==='guns'){
-    let best=-1, guns=-1; for(let i=0;i<defFleet.length;i++){ const s=defFleet[i]; if(s && s.alive && s.stats.valid){ const g=s.weapons.length; if(g>guns){ guns=g; best=i; } } } if(best!==-1) return best;
+    let best=-1, guns=-1
+    for(let i=0;i<defFleet.length;i++){ const s=defFleet[i]; if(s && s.alive && s.stats.valid){ const g=s.weapons.length; if(g>guns){ guns=g; best=i } } }
+    if(best!==-1) return best
   }
-  return defFleet.findIndex(s=>s.alive && s.stats.valid);
+  return defFleet.findIndex(s=>s.alive && s.stats.valid)
 }
 
-export function volley(attacker:Ship, defender:Ship, side:'P'|'E', logArr:string[], successThreshold:(aim:number, shieldTier:number)=>number, rollSuccesses:(numDice:number, threshold:number)=>number){
-  const thr = successThreshold(attacker.stats.aim, defender.stats.shieldTier);
+export function volley(attacker:Ship, defender:Ship, side:'P'|'E', logArr:string[], friends:Ship[]){
+  const thr = successThreshold(attacker.stats.aim, defender.stats.shieldTier)
   attacker.weapons.forEach((w:Part) => {
-    const succ = rollSuccesses(w.dice||0, thr);
-    const dmg = succ * (w.dmgPerHit||0);
-    if (succ > 0) {
-      defender.hull -= dmg;
-      logArr.push(`${side==='P'?'🟦':'🟥'} ${attacker.frame.name} → ${defender.frame.name} | ${w.name}: ${succ} hit(s) → ${dmg} hull (thr ≥ ${thr})`);
-      if (defender.hull <= 0) { defender.alive = false; defender.hull = 0; logArr.push(`💥 ${defender.frame.name} destroyed!`); }
-    } else {
-      logArr.push(`${side==='P'?'🟦':'🟥'} ${attacker.frame.name} misses with ${w.name} (thr ≥ ${thr})`);
+    if(w.riftDice) return
+    for(let i=0;i<(w.dice||0);i++){
+      const faces = w.faces||[]
+      const face = faces[Math.floor(Math.random()*faces.length)] || {}
+      if(face.dmg){
+        const dmg = face.dmg
+        defender.hull -= dmg
+        logArr.push(`${side==='P'?'🟦':'🟥'} ${attacker.frame.name} → ${defender.frame.name} | ${w.name}: auto ${dmg}`)
+        if(defender.hull<=0){ defender.alive=false; defender.hull=0; logArr.push(`💥 ${defender.frame.name} destroyed!`) }
+      } else if(typeof face.roll === 'number' && face.roll >= thr){
+        const dmg = w.dmgPerHit||0
+        defender.hull -= dmg
+        logArr.push(`${side==='P'?'🟦':'🟥'} ${attacker.frame.name} → ${defender.frame.name} | ${w.name}: roll ${face.roll} ≥ ${thr} → ${dmg}`)
+        if(defender.hull<=0){ defender.alive=false; defender.hull=0; logArr.push(`💥 ${defender.frame.name} destroyed!`) }
+      } else {
+        const rolled = typeof face.roll === 'number' ? face.roll : 'miss'
+        logArr.push(`${side==='P'?'🟦':'🟥'} ${attacker.frame.name} misses with ${w.name} (roll ${rolled} < ${thr})`)
+      }
+      if(face.self){ assignRiftSelfDamage(friends, side, logArr) }
     }
-  });
+  })
+  if(attacker.riftDice>0){
+    for(let i=0;i<attacker.riftDice;i++){
+      const roll = Math.floor(Math.random()*6)
+      const face = RIFT_FACES[roll]
+      if(face.dmg){
+        defender.hull -= face.dmg
+        logArr.push(`${side==='P'?'🟦':'🟥'} ${attacker.frame.name} Rift die hits for ${face.dmg}`)
+        if(defender.hull<=0){ defender.alive=false; defender.hull=0; logArr.push(`💥 ${defender.frame.name} destroyed!`) }
+      } else {
+        logArr.push(`${side==='P'?'🟦':'🟥'} ${attacker.frame.name} Rift die misses`)
+      }
+      if(face.self){
+        assignRiftSelfDamage(friends, side, logArr)
+      }
+    }
+  }
+}
+
+function assignRiftSelfDamage(friends:Ship[], side:'P'|'E', logArr:string[]){
+  const riftShips = friends.filter(s=>s.alive && s.riftDice>0)
+  if(riftShips.length===0) return
+  const sorted = [...riftShips].sort((a,b)=> (sizeRank(b.frame)-sizeRank(a.frame)) || (b.hull - a.hull))
+  const target = sorted.find(s=>s.hull<=1) || sorted[0]
+  target.hull -= 1
+  logArr.push(`${side==='P'?'🟦':'🟥'} ${target.frame.name} suffers 1 Rift backlash`)
+  if(target.hull<=0){ target.alive=false; target.hull=0; logArr.push(`💥 ${target.frame.name} destroyed by Rift backlash!`) }
 }
 
 export function genEnemyFleet(sector:number){
-  const spec = getSectorSpec(sector);
-  const boss = spec.boss;
-  const focus = boss ? getBossVariantFocus(sector) : undefined;
-  const options = [FRAMES.dread, FRAMES.cruiser, FRAMES.interceptor];
-  let remaining = Math.max(1, spec.enemyTonnage);
-  const ships:Ship[] = [] as unknown as Ship[];
-  let bossAssigned = false;
-  const minTonnage = Math.min(...options.map(f=>f.tonnage));
+  const spec = getSectorSpec(sector)
+  const boss = spec.boss
+  const focus = boss ? getBossVariantFocus(sector) : undefined
+  const options = [FRAMES.dread, FRAMES.cruiser, FRAMES.interceptor]
+  let remaining = Math.max(1, spec.enemyTonnage)
+  const ships:Ship[] = [] as unknown as Ship[]
+  let bossAssigned = false
+  const minTonnage = Math.min(...options.map(f=>f.tonnage))
 
-  // Predefined boss fleets for opponent faction at 5 and 10
   if(boss){
-    const opp = getOpponentFaction();
-    const bossSpec = getBossFleetFor(opp, sector);
+    const opp = getOpponentFaction()
+    const bossSpec = getBossFleetFor(opp, sector)
     if(bossSpec){
       return bossSpec.ships.map(s => {
-        const frame = FRAMES[s.frame];
-        const allParts: Part[] = ([] as Part[]).concat(PARTS.sources, PARTS.drives, PARTS.weapons, PARTS.computers, PARTS.shields, PARTS.hull);
-        const parts = s.parts.map(pid => allParts.find((p)=> p.id===pid)).filter((p): p is Part => !!p);
-        return makeShip(frame, parts);
-      }) as unknown as Ship[];
+        const frame = FRAMES[s.frame]
+        const allParts: Part[] = ([] as Part[]).concat(PARTS.sources, PARTS.drives, PARTS.weapons, PARTS.computers, PARTS.shields, PARTS.hull)
+        const parts = s.parts.map(pid => allParts.find((p)=> p.id===pid)).filter((p): p is Part => !!p)
+        return makeShip(frame, parts)
+      }) as unknown as Ship[]
     }
   }
   while(remaining >= minTonnage){
-    const viable = options.filter(f => f.tonnage <= remaining);
-    if(viable.length === 0) break;
-    const pick = viable[Math.floor(Math.random()*viable.length)];
-    const parts = randomEnemyPartsFor(pick, spec.enemyScienceCap, boss && !bossAssigned, focus);
-    ships.push(makeShip(pick, parts));
-    if(boss && !bossAssigned && pick.id!=='interceptor') bossAssigned = true;
-    remaining -= pick.tonnage;
+    const viable = options.filter(f => f.tonnage <= remaining)
+    if(viable.length === 0) break
+    const pick = viable[Math.floor(Math.random()*viable.length)]
+    const parts = randomEnemyPartsFor(pick, spec.enemyScienceCap, boss && !bossAssigned, focus)
+    ships.push(makeShip(pick, parts))
+    if(boss && !bossAssigned && pick.id!=='interceptor') bossAssigned = true
+    remaining -= pick.tonnage
   }
-  return ships;
+  return ships
 }
-
 

--- a/src/game/index.ts
+++ b/src/game/index.ts
@@ -5,19 +5,19 @@ import { FRAMES, type Frame, type FrameId } from '../config/frames'
 import { PARTS, ALL_PARTS, type Part } from '../config/parts'
 import { ECONOMY } from '../config/economy'
 export { FRAMES, type FrameId } from '../config/frames'
-export { PARTS, ALL_PARTS, type Part } from '../config/parts'
+export { PARTS, ALL_PARTS, type Part, RIFT_FACES } from '../config/parts'
 export { getSectorSpec, SECTORS } from '../config/pacing'
 export { nextTierCost } from '../config/economy'
 import type { BossVariant } from '../config/types'
 import type { FactionId } from '../config/factions'
 export { getBossFleetFor } from '../config/factions'
 
-export const isSource = (p:Part)=>"powerProd" in p;
-export const isDrive = (p:Part)=>"init" in p;
-export const isWeapon = (p:Part)=>"dice" in p;
-export const isComputer = (p:Part)=>"aim" in p;
-export const isShield = (p:Part)=>"shieldTier" in p;
-export const isHull = (p:Part)=>"extraHull" in p;
+export const isSource = (p:Part)=> p.cat === 'Source';
+export const isDrive = (p:Part)=> p.cat === 'Drive';
+export const isWeapon = (p:Part)=> p.cat === 'Weapon';
+export const isComputer = (p:Part)=> p.cat === 'Computer';
+export const isShield = (p:Part)=> p.cat === 'Shield';
+export const isHull = (p:Part)=> p.cat === 'Hull';
 
 // Safe frame lookup to avoid undefined access
 export function getFrame(id: FrameId){
@@ -75,7 +75,8 @@ export function makeShip(frame:Frame, parts:Part[]){
   const totalAim = parts.reduce((sum:number, p:Part)=> sum + (p.aim||0), 0);
   const totalShieldTier = parts.reduce((sum:number, p:Part)=> sum + (p.shieldTier||0), 0);
   const totalInit = parts.reduce((sum:number, p:Part)=> sum + (p.init||0), 0);
-  return { frame, parts, weapons, computer, shield, hullParts, drive, sources,
+  const riftDice = parts.reduce((sum:number, p:Part)=> sum + (p.riftDice||0), 0);
+  return { frame, parts, weapons, riftDice, computer, shield, hullParts, drive, sources,
     stats:{ hullCap, aim: totalAim, shieldTier: totalShieldTier, init: totalInit, powerProd, powerUse, valid },
     hull: hullCap, alive: true };
 }


### PR DESCRIPTION
## Summary
- support custom die faces across weapons and add spike launcher example
- roll weapon-specific faces during combat while retaining rift mechanics
- test flexible dice behaviour and update rift tests

## Testing
- `npx vitest run --reporter tap | tail -n 20`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b38e3838c883339d2cdc23ddd4e3ff