### PR TITLE
feat: add rare tech parts with configurable spawn chance

### DIFF
--- a/src/__tests__/dice.spec.ts
+++ b/src/__tests__/dice.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { makeShip, getFrame, PARTS } from '../game'
+import { makeShip, getFrame, PARTS, RARE_PARTS } from '../game'
 import { volley } from '../game/combat'
 
 describe('weapon dice faces', () => {
@@ -21,7 +21,7 @@ describe('weapon dice faces', () => {
   it('spike launcher deals big damage on spike face', () => {
     const src = PARTS.sources[0]
     const drv = PARTS.drives[0]
-    const spike = PARTS.weapons.find(p=>p.id==='spike_launcher')!
+    const spike = RARE_PARTS.find(p=>p.id==='spike_launcher')!
     const hullp = PARTS.hull.find(p=>p.id==='improved')!
     const attacker = makeShip(getFrame('interceptor'), [src, drv, spike])
     const defender = makeShip(getFrame('interceptor'), [src, drv, hullp])

--- a/src/__tests__/effects.spec.ts
+++ b/src/__tests__/effects.spec.ts
@@ -1,9 +1,9 @@
 import { describe, it, expect } from 'vitest'
-import { PARTS, partEffects } from '../config/parts'
+import { PARTS, RARE_PARTS, partEffects } from '../config/parts'
 
 describe('partEffects display', () => {
   it('shows spike launcher max damage and hit chance', () => {
-    const spike = PARTS.weapons.find(p=>p.id==='spike_launcher')!
+    const spike = RARE_PARTS.find(p=>p.id==='spike_launcher')!
     const eff = partEffects(spike)
     expect(eff).toContain('💥3')
     expect(eff).toContain('🎯17%')

--- a/src/__tests__/rare.spec.ts
+++ b/src/__tests__/rare.spec.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from 'vitest';
+import { rollInventory, setRareTechChance } from '../game';
+import { RARE_PARTS } from '../config/parts';
+
+describe('Rare tech generation', () => {
+  it('rollInventory can produce rare parts when chance is high', () => {
+    setRareTechChance(1);
+    const items = rollInventory({ Military: 1, Grid: 1, Nano: 1 }, 2);
+    const rareIds = RARE_PARTS.map(p => p.id);
+    expect(items.every(it => rareIds.includes(it.id))).toBe(true);
+    setRareTechChance(0.1);
+  });
+});
+

--- a/src/__tests__/rift.spec.ts
+++ b/src/__tests__/rift.spec.ts
@@ -1,12 +1,12 @@
 import { describe, it, expect } from 'vitest'
-import { makeShip, getFrame, PARTS } from '../game'
+import { makeShip, getFrame, PARTS, RARE_PARTS } from '../game'
 import { volley } from '../game/combat'
 
 describe('rift weapons', () => {
   it('assigns self-damage to largest killable rift ship', () => {
     const src = PARTS.sources[0]
     const drv = PARTS.drives[0]
-    const rift = PARTS.weapons.find(p=>p.id==='rift_cannon')!
+    const rift = RARE_PARTS.find(p=>p.id==='rift_cannon')!
     const attacker = makeShip(getFrame('interceptor'), [src, drv, rift])
     const ally = makeShip(getFrame('dread'), [src, drv, rift])
     const defender = makeShip(getFrame('interceptor'), [src, drv])
@@ -22,7 +22,7 @@ describe('rift weapons', () => {
   it('rift conductor grants extra rift die', () => {
     const src = PARTS.sources[0]
     const drv = PARTS.drives[0]
-    const rift = PARTS.weapons.find(p=>p.id==='rift_cannon')!
+    const rift = RARE_PARTS.find(p=>p.id==='rift_cannon')!
     const conductor = PARTS.hull.find(p=>p.id==='rift_conductor')!
     const attacker = makeShip(getFrame('interceptor'), [src, drv, rift, conductor])
     const defender = makeShip(getFrame('interceptor'), [src, drv])

--- a/src/__tests__/runtime.selftests.spec.ts
+++ b/src/__tests__/runtime.selftests.spec.ts
@@ -12,7 +12,7 @@ describe('Runtime self-tests (moved from App)', () => {
     const items = rollInventory(research, 8)
     const caps = tierCap(research)
     expect(items.length).toBe(8)
-    expect(items.every(p => p.tier === caps[p.tech_category as 'Military'|'Grid'|'Nano'])).toBe(true)
+    expect(items.every(p => p.rare || p.tier === caps[p.tech_category as 'Military'|'Grid'|'Nano'])).toBe(true)
   })
 
   it('makeShip valid for all frames', () => {

--- a/src/components/modals.tsx
+++ b/src/components/modals.tsx
@@ -207,7 +207,7 @@ export function TechListModal({ onClose, research }:{ onClose:()=>void, research
         <div className="text-lg font-semibold mb-2">Tech List</div>
         <div className="max-h-[60vh] overflow-y-auto pr-1 text-xs sm:text-sm space-y-3">
           {tracks.map(t => {
-            const parts = ALL_PARTS.filter(p=>p.tech_category===t).sort((a,b)=>a.tier-b.tier || a.cat.localeCompare(b.cat));
+            const parts = ALL_PARTS.filter(p=>p.tech_category===t && !p.rare).sort((a,b)=>a.tier-b.tier || a.cat.localeCompare(b.cat));
             return (
               <div key={t}>
                 <div className="font-medium mb-1">{t}</div>

--- a/src/config/factions.ts
+++ b/src/config/factions.ts
@@ -17,6 +17,7 @@ export const FACTIONS: readonly Faction[] = [
     description: 'All tech tracks start at Tier 2. Better shop quality early.',
     config: buildFactionConfig({
       research: { Military: 2, Grid: 2, Nano: 2 },
+      rareChance: 0.2,
     }),
   },
   {

--- a/src/config/game.ts
+++ b/src/config/game.ts
@@ -16,6 +16,7 @@ export type GameConfig = {
   startingFrame: FrameId;
   capacity: number;
   shopSize: number;
+  rareChance: number;
   economy: GameEconomy;
 };
 
@@ -30,6 +31,7 @@ export const BASE_CONFIG: GameConfig = {
   startingFrame: 'interceptor',
   capacity: INITIAL_CAPACITY.cap,
   shopSize: ECONOMY.shop.itemsBase,
+  rareChance: 0.1,
   economy: {},
 };
 
@@ -40,6 +42,7 @@ export type GameConfigOverrides = {
   startingFrame?: FrameId;
   capacity?: number;
   shopSize?: number;
+  rareChance?: number;
   economy?: GameEconomy;
 };
 
@@ -59,6 +62,7 @@ export function buildFactionConfig(overrides: GameConfigOverrides): GameConfig {
     startingFrame: overrides.startingFrame ?? BASE_CONFIG.startingFrame,
     capacity: overrides.capacity ?? BASE_CONFIG.capacity,
     shopSize: overrides.shopSize ?? BASE_CONFIG.shopSize,
+    rareChance: overrides.rareChance ?? BASE_CONFIG.rareChance,
     economy: {
       rerollBase: overrides.economy?.rerollBase ?? BASE_CONFIG.economy.rerollBase,
       creditMultiplier:

--- a/src/config/parts.ts
+++ b/src/config/parts.ts
@@ -24,6 +24,7 @@ export type Part = {
   cost: number;
   tech_category: TechTrack;
   cat: PartCategory;
+  rare?: boolean;
 };
 
 export type PartCatalog = {
@@ -137,36 +138,6 @@ export const PARTS: PartCatalog = {
       cat: "Weapon",
       tech_category: "Nano",
     },
-    {
-      id: "spike_launcher",
-      name: "Spike Launcher",
-      dice: 1,
-      dmgPerHit: 1,
-      faces: [
-        { roll: 0 },
-        { roll: 0 },
-        { roll: 0 },
-        { roll: 0 },
-        { roll: 0 },
-        { dmg: 3 },
-      ],
-      powerCost: 1,
-      tier: 1,
-      cost: 30,
-      cat: "Weapon",
-      tech_category: "Nano",
-    },
-    {
-      id: "rift_cannon",
-      name: "Rift Cannon",
-      riftDice: 1,
-      faces: RIFT_FACES,
-      powerCost: 2,
-      tier: 2,
-      cost: 65,
-      cat: "Weapon",
-      tech_category: "Nano",
-    },
   ],
   computers: [
     { id: "positron", name: "Positron Computer", aim: 1, powerCost: 1, tier: 1, cost: 25, cat: "Computer", tech_category: "Grid" },
@@ -192,6 +163,41 @@ export const PARTS: PartCatalog = {
   ],
 } as const;
 
+export const RARE_PARTS: Part[] = [
+  {
+    id: "spike_launcher",
+    name: "Spike Launcher",
+    dice: 1,
+    dmgPerHit: 1,
+    faces: [
+      { roll: 0 },
+      { roll: 0 },
+      { roll: 0 },
+      { roll: 0 },
+      { roll: 0 },
+      { dmg: 3 },
+    ],
+    powerCost: 1,
+    tier: 1,
+    cost: 30,
+    cat: "Weapon",
+    tech_category: "Nano",
+    rare: true,
+  },
+  {
+    id: "rift_cannon",
+    name: "Rift Cannon",
+    riftDice: 1,
+    faces: RIFT_FACES,
+    powerCost: 2,
+    tier: 2,
+    cost: 65,
+    cat: "Weapon",
+    tech_category: "Nano",
+    rare: true,
+  },
+];
+
 export const ALL_PARTS: Part[] = [
   ...PARTS.sources,
   ...PARTS.drives,
@@ -199,6 +205,7 @@ export const ALL_PARTS: Part[] = [
   ...PARTS.computers,
   ...PARTS.shields,
   ...PARTS.hull,
+  ...RARE_PARTS,
 ];
 
 export const PART_EFFECT_FIELDS = [

--- a/src/game/combat.ts
+++ b/src/game/combat.ts
@@ -1,6 +1,6 @@
 import { type Part, RIFT_FACES } from '../config/parts'
 import { type Ship, type InitiativeEntry } from '../config/types'
-import { FRAMES, makeShip, randomEnemyPartsFor, sizeRank, getBossVariantFocus, getOpponentFaction, getBossFleetFor, PARTS, successThreshold } from './index'
+import { FRAMES, makeShip, randomEnemyPartsFor, sizeRank, getBossVariantFocus, getOpponentFaction, getBossFleetFor, ALL_PARTS, successThreshold } from './index'
 import { getSectorSpec } from './index'
 
 export function buildInitiative(pFleet:Ship[], eFleet:Ship[]): InitiativeEntry[] {
@@ -93,8 +93,7 @@ export function genEnemyFleet(sector:number){
     if(bossSpec){
       return bossSpec.ships.map(s => {
         const frame = FRAMES[s.frame]
-        const allParts: Part[] = ([] as Part[]).concat(PARTS.sources, PARTS.drives, PARTS.weapons, PARTS.computers, PARTS.shields, PARTS.hull)
-        const parts = s.parts.map(pid => allParts.find((p)=> p.id===pid)).filter((p): p is Part => !!p)
+        const parts = s.parts.map(pid => ALL_PARTS.find(p=>p.id===pid)).filter((p): p is Part => !!p)
         return makeShip(frame, parts)
       }) as unknown as Ship[]
     }

--- a/src/game/index.ts
+++ b/src/game/index.ts
@@ -2,10 +2,10 @@
 
 // ------------------------------- Data Models -------------------------------
 import { FRAMES, type Frame, type FrameId } from '../config/frames'
-import { PARTS, ALL_PARTS, type Part } from '../config/parts'
+import { PARTS, ALL_PARTS, RARE_PARTS, type Part } from '../config/parts'
 import { ECONOMY } from '../config/economy'
 export { FRAMES, type FrameId } from '../config/frames'
-export { PARTS, ALL_PARTS, type Part, RIFT_FACES } from '../config/parts'
+export { PARTS, RARE_PARTS, ALL_PARTS, type Part, RIFT_FACES } from '../config/parts'
 export { getSectorSpec, SECTORS } from '../config/pacing'
 export { nextTierCost } from '../config/economy'
 import type { BossVariant } from '../config/types'
@@ -89,28 +89,42 @@ export function tierCap(research:{Military:number, Grid:number, Nano:number}): R
   };
 }
 
+let RARE_TECH_CHANCE = 0.1;
+export function setRareTechChance(ch:number){ RARE_TECH_CHANCE = ch; }
+export function getRareTechChance(){ return RARE_TECH_CHANCE; }
+
 export function rollInventory(research:{Military:number, Grid:number, Nano:number}, count: number = ECONOMY.shop.itemsBase){
   const capByCat = tierCap(research);
 
-  // Filter parts pool to only include parts within research tier limits
+  // Filter parts pool to only include parts within research tier limits and exclude rares
   const pool = ALL_PARTS.filter((p:Part) =>
-    p.tier === capByCat[p.tech_category as 'Military'|'Grid'|'Nano']
+    !p.rare && p.tier === capByCat[p.tech_category as 'Military'|'Grid'|'Nano']
   );
 
   const items:Part[] = [];
-  
-  // Randomly select parts until we hit the count, avoiding duplicates
-  const available = [...pool]; // Copy pool to avoid modifying original
-  while(items.length < count && available.length > 0) {
-    const idx = Math.floor(Math.random() * available.length);
-    const part = available[idx];
-    items.push(part);
-    available.splice(idx, 1); // Remove selected part from available pool
-  }
-  // If we run out of unique parts, fill remaining slots with random parts from original pool
-  while(items.length < count && pool.length > 0) {
-    const idx = Math.floor(Math.random() * pool.length);
-    items.push(pool[idx]);
+
+  const available = [...pool];
+  while(items.length < count){
+    const useRare = Math.random() < RARE_TECH_CHANCE;
+    if(useRare && RARE_PARTS.length > 0){
+      const ridx = Math.floor(Math.random() * RARE_PARTS.length);
+      items.push(RARE_PARTS[ridx]);
+      continue;
+    }
+    if(available.length > 0){
+      const idx = Math.floor(Math.random() * available.length);
+      const part = available[idx];
+      items.push(part);
+      available.splice(idx,1);
+    } else if(pool.length > 0){
+      const idx = Math.floor(Math.random() * pool.length);
+      items.push(pool[idx]);
+    } else if(RARE_PARTS.length > 0){
+      const ridx = Math.floor(Math.random() * RARE_PARTS.length);
+      items.push(RARE_PARTS[ridx]);
+    } else {
+      break;
+    }
   }
 
   return items;

--- a/src/game/setup.ts
+++ b/src/game/setup.ts
@@ -2,7 +2,7 @@ import { type Research, type Resources } from '../config/defaults'
 import { type FrameId } from '../config/frames'
 import { getFaction, type FactionId } from '../config/factions'
 import { type Part } from '../config/parts'
-import { getFrame, makeShip, rollInventory, setPlayerFaction, pickOpponentFaction, setEconomyModifiers } from './index'
+import { getFrame, makeShip, rollInventory, setPlayerFaction, pickOpponentFaction, setEconomyModifiers, setRareTechChance } from './index'
 import { getStartingShipCount, getBaseRerollCost, getInitialCapacityForDifficulty } from '../config/difficulty'
 import { type DifficultyId } from '../config/types'
 
@@ -25,6 +25,7 @@ export function initNewRun({ difficulty, faction }: NewRunParams): NewRunState{
   const creditMult = f.config.economy.creditMultiplier ?? 1;
   const materialMult = f.config.economy.materialMultiplier ?? 1;
   setEconomyModifiers({ credits: creditMult, materials: materialMult });
+  setRareTechChance(f.config.rareChance);
 
   const res: Resources = { ...f.config.resources };
   const research: Research = { ...f.config.research } as Research;

--- a/src/pages/OutpostPage.tsx
+++ b/src/pages/OutpostPage.tsx
@@ -98,7 +98,7 @@ export function OutpostPage({
   function nextUnlocksFor(track:'Military'|'Grid'|'Nano'){
     const curr = (research as Research)[track]||1;
     const next = Math.min(3, curr+1);
-    const items = ALL_PARTS.filter(p=> p.tech_category===track && p.tier===next);
+    const items = ALL_PARTS.filter(p=> !p.rare && p.tech_category===track && p.tier===next);
     return items;
   }
   function militaryNextNote(){


### PR DESCRIPTION
## Summary
- add rare tech part list for items like Rift Cannon and Spike Launcher
- allow game config to specify rare tech chance and boost scholars
- update inventory rolls, UI, and tests for rare tech generation

## Testing
- `CI=1 npx vitest run src/__tests__/runtime.selftests.spec.ts`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b3aae81b2883338c1cfc94b783c6f7