### PR TITLE
Show rift dice as weapons

### DIFF
--- a/src/__tests__/boss.spec.tsx
+++ b/src/__tests__/boss.spec.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
 import App from '../App'
 import { getBossVariants, getOpponentFaction, getBossFleetFor } from '../game'
@@ -21,6 +21,11 @@ describe('Boss variants and planning', () => {
   })
 
   it('Combat Plan shows boss variant labels for sectors 5 and 10', async () => {
+    let seed = 1
+    const rand = vi.spyOn(Math, 'random').mockImplementation(() => {
+      seed = (seed * 16807) % 2147483647
+      return (seed - 1) / 2147483646
+    })
     render(<App />)
     fireEvent.click(screen.getByRole('button', { name: /Consortium of Scholars/i }))
     fireEvent.click(screen.getByRole('button', { name: /Easy/i }))
@@ -30,6 +35,7 @@ describe('Boss variants and planning', () => {
     fireEvent.click(screen.getByRole('button', { name: /Return to Outpost/i }))
     await screen.findByRole('button', { name: /Combat Plan/i })
     fireEvent.click(screen.getByRole('button', { name: /Combat Plan/i }))
+    rand.mockRestore()
 
     // Sector rows appear with variants summary for boss sectors
     const s5 = screen.getByText(/Sector 5 \(Boss\)/i)

--- a/src/__tests__/rift.ui.spec.tsx
+++ b/src/__tests__/rift.ui.spec.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import { CompactShip } from '../components/ui'
-import { makeShip, getFrame, PARTS } from '../game'
+import { makeShip, getFrame, PARTS, type Part } from '../game'
 
 describe('CompactShip rift dice display', () => {
   it('shows rift dice when only rift conductor is installed', () => {
@@ -12,5 +12,26 @@ describe('CompactShip rift dice display', () => {
     render(<CompactShip ship={ship} side="P" active={false} />)
     expect(screen.queryByText(/No weapons/i)).toBeNull()
     expect(screen.getByText(/🕳️/)).toBeInTheDocument()
+  })
+
+  it('shows dice on non-weapon parts with dice', () => {
+    const src = PARTS.sources[0]
+    const drv = PARTS.drives[0]
+    const hybrid: Part = {
+      id: 'shield_gun',
+      name: 'Shield Gun',
+      cat: 'Shield',
+      tier: 1,
+      cost: 0,
+      tech_category: 'Nano',
+      shieldTier: 1,
+      dice: 1,
+      dmgPerHit: 1,
+      faces: [{ dmg: 1 }],
+    }
+    const ship = makeShip(getFrame('interceptor'), [src, drv, hybrid])
+    render(<CompactShip ship={ship} side="P" active={false} />)
+    expect(screen.queryByText(/No weapons/i)).toBeNull()
+    expect(screen.getByText('1🎲 × 1')).toBeInTheDocument()
   })
 })

--- a/src/__tests__/rift.ui.spec.tsx
+++ b/src/__tests__/rift.ui.spec.tsx
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { CompactShip } from '../components/ui'
+import { makeShip, getFrame, PARTS } from '../game'
+
+describe('CompactShip rift dice display', () => {
+  it('shows rift dice when only rift conductor is installed', () => {
+    const src = PARTS.sources[0]
+    const drv = PARTS.drives[0]
+    const conductor = PARTS.hull.find(p=>p.id==='rift_conductor')!
+    const ship = makeShip(getFrame('interceptor'), [src, drv, conductor])
+    render(<CompactShip ship={ship} side="P" active={false} />)
+    expect(screen.queryByText(/No weapons/i)).toBeNull()
+    expect(screen.getByText(/🕳️/)).toBeInTheDocument()
+  })
+})

--- a/src/components/ui.tsx
+++ b/src/components/ui.tsx
@@ -30,18 +30,26 @@ export function CompactShip({ ship, side, active }:{ship:Ship, side:'P'|'E', act
       <HullPips current={Math.max(0, ship.hull)} max={ship.stats.hullCap} />
       {/* Dice/Damage summary per weapon */}
       <div className="mt-1 flex flex-wrap gap-1 min-h-[18px]">
-        {ship.weapons.length>0 ? ship.weapons.map((w:Part, i:number)=> {
+        {ship.weapons.map((w:Part, i:number)=> {
           const maxDmg = Math.max(w.dmgPerHit||0, ...(w.faces||[]).map(f=>f.dmg||0));
           return (
             <span key={i} className="px-1.5 py-0.5 rounded bg-zinc-800 border border-zinc-700 text-[10px] whitespace-nowrap">
               {w.dice||0}🎲 × {maxDmg}
             </span>
           );
-        }) : (
+        })}
+        {ship.riftDice>0 && (
+          <span key="rift" className="px-1.5 py-0.5 rounded bg-zinc-800 border border-zinc-700 text-[10px] whitespace-nowrap">
+            {ship.riftDice}🕳️
+          </span>
+        )}
+        {ship.weapons.length===0 && ship.riftDice===0 && (
           <span className="text-[10px] opacity-60">No weapons</span>
         )}
       </div>
-      <div className="mt-1 text-[10px] opacity-80 line-clamp-2 min-h-[20px]">{ship.weapons.map((w:Part)=>w.name).join(', ')||'—'}</div>
+      <div className="mt-1 text-[10px] opacity-80 line-clamp-2 min-h-[20px]">{
+        [...ship.weapons.map((w:Part)=>w.name), ...(ship.riftDice>0 ? [`${ship.riftDice} Rift die${ship.riftDice>1?'s':''}`] : [])].join(', ')||'—'
+      }</div>
       <div className="absolute top-1 right-1"><PowerBadge use={ship.stats.powerUse} prod={ship.stats.powerProd} /></div>
       {dead && <div className="absolute inset-0 grid place-items-center text-2xl text-zinc-300">✖</div>}
     </div>

--- a/src/components/ui.tsx
+++ b/src/components/ui.tsx
@@ -23,6 +23,7 @@ export function HullPips({ current, max }:{current:number, max:number}){
 }
 export function CompactShip({ ship, side, active }:{ship:Ship, side:'P'|'E', active:boolean}){
   const dead = !ship.alive || ship.hull<=0;
+  const weaponParts = ship.parts.filter((p:Part)=> (p.dice||0) > 0 || (p.riftDice||0) > 0);
   return (
     <div className={`relative w-28 sm:w-32 p-2 rounded-xl border shadow-sm ${dead? 'border-zinc-700 bg-zinc-900 opacity-60' : side==='P' ? 'border-sky-600/60 bg-slate-900' : 'border-pink-600/60 bg-zinc-900'} ${active? 'ring-2 ring-amber-400 animate-pulse':''}`}>
       <div className="text-[11px] sm:text-xs font-semibold truncate pr-6">{ship.frame.name}</div>
@@ -30,25 +31,22 @@ export function CompactShip({ ship, side, active }:{ship:Ship, side:'P'|'E', act
       <HullPips current={Math.max(0, ship.hull)} max={ship.stats.hullCap} />
       {/* Dice/Damage summary per weapon */}
       <div className="mt-1 flex flex-wrap gap-1 min-h-[18px]">
-        {ship.weapons.map((w:Part, i:number)=> {
-          const maxDmg = Math.max(w.dmgPerHit||0, ...(w.faces||[]).map(f=>f.dmg||0));
+        {weaponParts.map((p:Part, i:number)=> {
+          const dice = p.riftDice || p.dice || 0;
+          const icon = p.riftDice ? '🕳️' : '🎲';
+          const maxDmg = Math.max(p.dmgPerHit||0, ...(p.faces||[]).map(f=>f.dmg||0));
           return (
             <span key={i} className="px-1.5 py-0.5 rounded bg-zinc-800 border border-zinc-700 text-[10px] whitespace-nowrap">
-              {w.dice||0}🎲 × {maxDmg}
+              {dice}{icon}{maxDmg>0 ? ` × ${maxDmg}` : ''}
             </span>
           );
         })}
-        {ship.riftDice>0 && (
-          <span key="rift" className="px-1.5 py-0.5 rounded bg-zinc-800 border border-zinc-700 text-[10px] whitespace-nowrap">
-            {ship.riftDice}🕳️
-          </span>
-        )}
-        {ship.weapons.length===0 && ship.riftDice===0 && (
+        {weaponParts.length===0 && (
           <span className="text-[10px] opacity-60">No weapons</span>
         )}
       </div>
       <div className="mt-1 text-[10px] opacity-80 line-clamp-2 min-h-[20px]">{
-        [...ship.weapons.map((w:Part)=>w.name), ...(ship.riftDice>0 ? [`${ship.riftDice} Rift die${ship.riftDice>1?'s':''}`] : [])].join(', ')||'—'
+        weaponParts.map((p:Part)=> p.riftDice ? `${p.riftDice} Rift die${p.riftDice>1?'s':''}` : p.name).join(', ') || '—'
       }</div>
       <div className="absolute top-1 right-1"><PowerBadge use={ship.stats.powerUse} prod={ship.stats.powerProd} /></div>
       {dead && <div className="absolute inset-0 grid place-items-center text-2xl text-zinc-300">✖</div>}


### PR DESCRIPTION
## Summary
- display rift dice in ship weapon summary
- add test for rift-conductor-only ships

## Testing
- `npm run test:run`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b3b1fe00b483338e543329ca2765b3