### PR TITLE
Fix dock UI elements and dynamic capacity

### DIFF
--- a/src/__tests__/factions.spec.tsx
+++ b/src/__tests__/factions.spec.tsx
@@ -21,7 +21,7 @@ describe('Factions', () => {
     render(<App />)
     fireEvent.click(screen.getByRole('button', { name: /Crimson Vanguard/i }))
     fireEvent.click(screen.getByRole('button', { name: /Easy/i }))
-    expect(screen.getAllByText(/Cruiser/i).length).toBeGreaterThan(0)
+    expect(screen.getAllByTitle(/Cruiser/i).length).toBeGreaterThan(0)
   })
 
   it('Raiders start with T2 weapon (Antimatter Cannon) on Interceptor', () => {

--- a/src/components/modals.tsx
+++ b/src/components/modals.tsx
@@ -1,6 +1,8 @@
 // React import not required with modern JSX transform
 import { FACTIONS } from '../config/factions'
 import { SECTORS, getBossVariants, getBossFleetFor, getOpponentFaction, ALL_PARTS, makeShip, FRAMES } from '../game'
+import { getInitialCapacityForDifficulty } from '../config/difficulty'
+import { BASE_CONFIG } from '../config/game'
 import { CompactShip } from './ui'
 import { type Ship } from '../config/types'
 import { partEffects } from '../config/parts'
@@ -26,6 +28,8 @@ function BossFleetPreview({ sector }:{ sector:5|10 }){
 }
 
 export function RulesModal({ onDismiss }:{ onDismiss:()=>void }){
+  const dockStart = getInitialCapacityForDifficulty('easy', BASE_CONFIG.startingFrame);
+  const dockCircles = '🟢'.repeat(dockStart);
   return (
     <div className="fixed inset-0 z-40 flex items-end sm:items-center justify-center p-3 bg-black/60">
       <div className="w-full max-w-lg bg-zinc-900 border border-zinc-700 rounded-2xl p-4 shadow-xl">
@@ -36,7 +40,7 @@ export function RulesModal({ onDismiss }:{ onDismiss:()=>void }){
           <div><b>Combat.</b> Ships act from highest 🚀 to lowest. Weapons roll 🎲; 1 misses and 6 hits. 🎯 lowers the roll needed while 🛡️ raises it.</div>
           <div><b>Outpost.</b> Between battles spend 💰 credits and 🧱 materials to buy parts, build ships, and reroll the shop. Each reroll costs more.</div>
           <div><b>Research.</b> Use 🔬 science on Military, Grid, and Nano to unlock higher-tier parts and ship upgrades.</div>
-          <div><b>Ships & Power.</b> Your dock starts with 🟢🟢🟢🟢🟢🟢 capacity. Ships cost 🟢 by size and each needs a ⚡ Source and a Drive. Keep power use within supply.</div>
+          <div><b>Ships & Power.</b> Your dock starts with {dockCircles} capacity. Ships cost 🟢 by size and each needs a ⚡ Source and a Drive. Keep power use within supply.</div>
           <div><b>Progress.</b> Winning a battle advances you to the next sector and grants rewards. Bosses await at sectors 5 and 10.</div>
         </div>
         <div className="mt-3"><button onClick={onDismiss} className="w-full px-4 py-2 rounded-xl bg-emerald-600">Let’s go</button></div>

--- a/src/components/ui.tsx
+++ b/src/components/ui.tsx
@@ -50,7 +50,12 @@ export function CompactShip({ ship, side, active }:{ship:Ship, side:'P'|'E', act
   const weaponParts = ship.parts.filter((p:Part)=> (p.dice||0) > 0 || (p.riftDice||0) > 0);
   return (
     <div className={`relative w-28 sm:w-32 p-2 rounded-xl border shadow-sm ${dead? 'border-zinc-700 bg-zinc-900 opacity-60' : side==='P' ? 'border-sky-600/60 bg-slate-900' : 'border-pink-600/60 bg-zinc-900'} ${active? 'ring-2 ring-amber-400 animate-pulse':''}`}>
-      <div className="text-[11px] sm:text-xs font-semibold truncate pr-6">{ship.frame.name}</div>
+      <div
+        className="text-[11px] sm:text-xs font-semibold truncate pr-6"
+        title={ship.frame.name}
+      >
+        🟢 {ship.frame.tonnage}
+      </div>
       <div className="text-[10px] opacity-70">🚀 {ship.stats.init} • 🎯 {ship.stats.aim} • 🛡️ {ship.stats.shieldTier}</div>
       <HullPips current={Math.max(0, ship.hull)} max={ship.stats.hullCap} />
       {/* Dice/Damage summary per weapon */}

--- a/src/pages/OutpostPage.tsx
+++ b/src/pages/OutpostPage.tsx
@@ -165,7 +165,27 @@ export function OutpostPage({
           </div>
         ); })()}
         <div className="mt-2 grid grid-cols-2 gap-2">
-          <button onClick={upgradeDock} disabled={dockAtCap} className={`px-3 py-3 rounded-xl ${dockAtCap? 'bg-zinc-700 opacity-60' : 'bg-indigo-600 hover:bg-indigo-500 active:scale-95'}`}>{dockAtCap ? 'Capacity Maxed' : `Expand Capacity +${ECONOMY.dockUpgrade.capacityDelta} (${dockCost.materials}🧱 + ${dockCost.credits}¢)`}</button>
+          <button
+            onClick={upgradeDock}
+            disabled={dockAtCap}
+            className={`px-3 py-3 rounded-xl ${dockAtCap? 'bg-zinc-700 opacity-60' : 'bg-indigo-600 hover:bg-indigo-500 active:scale-95'}`}
+          >
+            {dockAtCap ? (
+              'Capacity Maxed'
+            ) : (
+              <span className="inline-flex items-center gap-1">
+                <span>Expand Capacity</span>
+                <span className="inline-flex gap-0.5">
+                  {Array.from({length: ECONOMY.dockUpgrade.capacityDelta}).map((_, i) => (
+                    <span key={i} className="w-2 h-2 rounded-full bg-zinc-700" />
+                  ))}
+                </span>
+                <span>
+                  ({dockCost.materials}🧱 + {dockCost.credits}¢)
+                </span>
+              </span>
+            )}
+          </button>
           <div className="px-3 py-3 rounded-xl bg-zinc-900 border border-zinc-700 text-sm">
             <div>Capacity: <b>{capacity.cap}</b> • Used: <b>{tonnage.used}</b></div>
             <DockSlots used={tonnage.used} cap={capacity.cap} preview={dockPreview===null?undefined:dockPreview} />


### PR DESCRIPTION
## Summary
- Replace ship name with dock cost icon in compact ship view
- Show capacity increase with empty dock circles in hangar upgrade button
- Render starting dock capacity from configuration in rules modal
- Adjust faction test to query ship by title

## Testing
- `npm test src/__tests__/factions.spec.tsx -- --run` *(fails: Test timed out in auto.victory and boss.predefined)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b54a87b94483338f8a9c46125b8d53