### PR TITLE
Display slot usage for parts and blueprints

### DIFF
--- a/src/__tests__/slots.spec.tsx
+++ b/src/__tests__/slots.spec.tsx
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ItemCard } from '../components/ui';
+import { PARTS } from '../config/parts';
+import App from '../App';
+
+async function toOutpost(faction: RegExp) {
+  render(<App />);
+  fireEvent.click(screen.getByRole('button', { name: faction }));
+  fireEvent.click(screen.getByRole('button', { name: /Easy/i }));
+  fireEvent.click(screen.getByRole('button', { name: /Let’s go/i }));
+  fireEvent.click(screen.getByRole('button', { name: /Auto/i }));
+  await screen.findByText(/^Victory$/i, undefined, { timeout: 10000 });
+  fireEvent.click(screen.getByRole('button', { name: /Return to Outpost/i }));
+  await screen.findByText(/Outpost Inventory/i);
+}
+
+describe('slot displays', () => {
+  it('shows slot usage in ItemCard', () => {
+    const cluster = PARTS.weapons.find(p => p.id === 'cluster_missiles')!;
+    render(<ItemCard item={cluster} canAfford={true} ghostDelta={null as any} onBuy={() => {}} />);
+    expect(screen.getByText(/2 slots/i)).toBeInTheDocument();
+  });
+
+  it('shows slots in Class Blueprint header for Cruiser', async () => {
+    await toOutpost(/Crimson Vanguard/i);
+    const header = await screen.findByText(/Class Blueprint — Cruiser/i);
+    expect(header.textContent).toMatch(/4\/8/);
+  }, 20000);
+});
+

--- a/src/components/ui.tsx
+++ b/src/components/ui.tsx
@@ -82,9 +82,14 @@ export function ItemCard({ item, canAfford, onBuy, ghostDelta }:{item:Part, canA
     <div className={`p-3 rounded-xl border bg-zinc-900 transition ${canAfford? 'border-zinc-700 hover:border-zinc-500 hover:bg-zinc-800/70' : 'border-zinc-800 opacity-90'}`}>
       <div className="flex items-start justify-between gap-2">
         <div>
-          <div className="font-semibold text-sm sm:text-base leading-tight">{item.name}</div>
-          <div className="text-[11px] sm:text-xs opacity-70 mt-0.5">{(() => { const eff = partEffects(item).join(' • '); return `${item.cat} • Tier ${item.tier}${eff ? ' • ' + eff : ''}`; })()}</div>
-          <div className="text-[11px] sm:text-xs mt-1">{partDescription(item)}</div>
+            <div className="font-semibold text-sm sm:text-base leading-tight">{item.name}</div>
+            <div className="text-[11px] sm:text-xs opacity-70 mt-0.5">{(() => {
+              const eff = partEffects(item).join(' • ');
+              const slots = item.slots || 1;
+              const slotLabel = `⬛ ${slots} slot${slots>1?'s':''}`;
+              return `${item.cat} • Tier ${item.tier} • ${slotLabel}${eff ? ' • ' + eff : ''}`;
+            })()}</div>
+            <div className="text-[11px] sm:text-xs mt-1">{partDescription(item)}</div>
         </div>
         <div className="text-sm sm:text-base font-semibold whitespace-nowrap">{item.cost}¢</div>
       </div>

--- a/src/pages/OutpostPage.tsx
+++ b/src/pages/OutpostPage.tsx
@@ -74,6 +74,8 @@ export function OutpostPage({
   };
   const dockAtCap = capacity.cap >= ECONOMY.dockUpgrade.capacityMax;
   const rrInc = Math.max(1, Math.floor(ECONOMY.reroll.increment * econ.credits));
+  const currentBlueprint = blueprints[focusedShip?.frame.id as FrameId] || [];
+  const bpSlotsUsed = currentBlueprint.reduce((a,p)=>a+(p.slots||1),0);
   const nextUpgrade = (()=>{
     if(!focusedShip) return null;
     if(focusedShip.frame.id==='interceptor') return {
@@ -171,11 +173,11 @@ export function OutpostPage({
             <DockSlots used={tonnage.used} cap={capacity.cap} preview={dockPreview===null?undefined:dockPreview} />
           </div>
         </div>
-        {/* Blueprint Manager with Sell */}
-        <div className="mt-3">
-          <div className="text-sm font-semibold mb-1">Class Blueprint — {focusedShip?.frame.name}</div>
-          <div className="grid grid-cols-2 sm:grid-cols-3 gap-2">
-            {blueprints[focusedShip?.frame.id as FrameId]?.map((p, idx)=> (
+          {/* Blueprint Manager with Sell */}
+          <div className="mt-3">
+            <div className="text-sm font-semibold mb-1">Class Blueprint — {focusedShip?.frame.name} ⬛ {bpSlotsUsed}/{focusedShip?.frame.tiles}</div>
+            <div className="grid grid-cols-2 sm:grid-cols-3 gap-2">
+              {currentBlueprint.map((p, idx)=> (
               <div key={idx} className="p-2 rounded border border-zinc-700 bg-zinc-900 text-xs">
                 <div className="font-medium text-sm">{p.name}</div>
                 <div className="opacity-70">{(() => { const eff = partEffects(p).join(' • '); return `${p.cat} • Tier ${p.tier}${eff ? ' • ' + eff : ''}`; })()}</div>


### PR DESCRIPTION
## Summary
- Show each shop item’s tile usage in its details
- Track total slots for current class blueprint and display used/total in header
- Add tests confirming slot counts in ItemCard and Cruiser blueprints

## Testing
- `npm run test:run`
- `npx vitest run src/__tests__/slots.spec.tsx`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b54c65d8f48333a55ea54af7b6301c