### PR TITLE
feat: show slot usage in shop previews

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -130,7 +130,30 @@ export default function EclipseIntegrated(){
     });
   }
   function canInstallOnClass(frameId:FrameId, part:Part){ return canInstallClass(blueprints as Record<FrameId, Part[]>, frameId, part); }
-  function ghost(ship:Ship, part:Part): GhostDelta { const frameId = ship.frame.id as FrameId; const chk = canInstallOnClass(frameId, part); const base = makeShip(ship.frame, blueprints[frameId]); return { targetName: ship.frame.name + " (class)", use: chk.tmp.stats.powerUse, prod: chk.tmp.stats.powerProd, valid: chk.tmp.stats.valid, initBefore: base.stats.init, initAfter: chk.tmp.stats.init, initDelta: chk.tmp.stats.init - base.stats.init, hullBefore: base.stats.hullCap, hullAfter: chk.tmp.stats.hullCap, hullDelta: chk.tmp.stats.hullCap - base.stats.hullCap }; }
+  function ghost(ship:Ship, part:Part): GhostDelta {
+    const frameId = ship.frame.id as FrameId;
+    const chk = canInstallOnClass(frameId, part);
+    const base = makeShip(ship.frame, blueprints[frameId]);
+    const powerOk = !!chk.tmp.drive && chk.tmp.sources.length>0 && chk.tmp.stats.powerUse <= chk.tmp.stats.powerProd;
+    const slotsUsed = chk.slotsUsed || ([...blueprints[frameId], part].reduce((a,p)=>a+(p.slots||1),0));
+    const slotCap = chk.slotCap || getFrame(frameId).tiles;
+    const slotOk = slotsUsed <= slotCap;
+    return {
+      targetName: ship.frame.name + " (class)",
+      use: chk.tmp.stats.powerUse,
+      prod: chk.tmp.stats.powerProd,
+      valid: powerOk,
+      slotsUsed,
+      slotCap,
+      slotOk,
+      initBefore: base.stats.init,
+      initAfter: chk.tmp.stats.init,
+      initDelta: chk.tmp.stats.init - base.stats.init,
+      hullBefore: base.stats.hullCap,
+      hullAfter: chk.tmp.stats.hullCap,
+      hullDelta: chk.tmp.stats.hullCap - base.stats.hullCap
+    };
+  }
   function buyAndInstall(part:Part){
     if(resources.credits < (part.cost||0)) return;
     const ship = fleet[focused];

--- a/src/__tests__/slots.spec.tsx
+++ b/src/__tests__/slots.spec.tsx
@@ -27,5 +27,47 @@ describe('slot displays', () => {
     const header = await screen.findByText(/Class Blueprint — Cruiser/i);
     expect(header.textContent).toMatch(/4\/8/);
   }, 20000);
+
+  it('previews slot usage in ItemCard ghost delta', () => {
+    const part = PARTS.weapons[0];
+    const ghost = {
+      targetName: 'Interceptor',
+      use: 0,
+      prod: 0,
+      valid: true,
+      slotsUsed: 5,
+      slotCap: 6,
+      slotOk: true,
+      initBefore: 0,
+      initAfter: 0,
+      initDelta: 0,
+      hullBefore: 0,
+      hullAfter: 0,
+      hullDelta: 0,
+    };
+    render(<ItemCard item={part} canAfford={true} ghostDelta={ghost as any} onBuy={() => {}} />);
+    expect(screen.getByText('⬛ 5/6 ✔️')).toBeInTheDocument();
+  });
+
+  it('shows ❌ when slot limit exceeded in preview', () => {
+    const part = PARTS.weapons[0];
+    const ghost = {
+      targetName: 'Interceptor',
+      use: 0,
+      prod: 0,
+      valid: true,
+      slotsUsed: 7,
+      slotCap: 6,
+      slotOk: false,
+      initBefore: 0,
+      initAfter: 0,
+      initDelta: 0,
+      hullBefore: 0,
+      hullAfter: 0,
+      hullDelta: 0,
+    };
+    render(<ItemCard item={part} canAfford={true} ghostDelta={ghost as any} onBuy={() => {}} />);
+    expect(screen.getByText('⬛ 7/6 ❌')).toBeInTheDocument();
+  });
 });
 

--- a/src/components/ui.tsx
+++ b/src/components/ui.tsx
@@ -104,6 +104,7 @@ export function ItemCard({ item, canAfford, onBuy, ghostDelta }:{item:Part, canA
         <div className="mt-2 text-[11px] sm:text-xs grid grid-cols-2 gap-x-3 gap-y-1">
           <div className="col-span-2 opacity-70">After install on {ghostDelta.targetName}:</div>
           <div className={`${ghostDelta.valid? 'text-emerald-300':'text-rose-300'}`}>⚡ {ghostDelta.use}/{ghostDelta.prod} {ghostDelta.valid? '✔️' : '❌'}</div>
+          <div className={`${ghostDelta.slotOk? 'text-emerald-300':'text-rose-300'}`}>⬛ {ghostDelta.slotsUsed}/{ghostDelta.slotCap} {ghostDelta.slotOk? '✔️' : '❌'}</div>
           {ghostDelta.initDelta!==0 && <div>🚀 {ghostDelta.initBefore} → <b>{ghostDelta.initAfter}</b></div>}
           {ghostDelta.hullDelta!==0 && <div>Hull {ghostDelta.hullBefore} → <b>{ghostDelta.hullAfter}</b></div>}
         </div>

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -16,6 +16,9 @@ export type GhostDelta = {
   use: number;
   prod: number;
   valid: boolean;
+  slotsUsed: number;
+  slotCap: number;
+  slotOk: boolean;
   initBefore: number;
   initAfter: number;
   initDelta: number;

--- a/src/game/blueprints.ts
+++ b/src/game/blueprints.ts
@@ -11,8 +11,9 @@ export function canInstallOnClass(blueprints:Record<FrameId, Part[]>, frameId:Fr
   const frame = getFrame(frameId);
   const nextParts = [...blueprints[frameId], part];
   const tmp = makeShip(frame, nextParts);
-  const tilesOk = nextParts.length <= frame.tiles;
-  return { ok: tilesOk, tmp };
+  const slotsUsed = nextParts.reduce((a,p)=>a+(p.slots||1),0);
+  const tilesOk = slotsUsed <= frame.tiles;
+  return { ok: tilesOk, tmp, slotsUsed, slotCap: frame.tiles };
 }
 
 export function updateBlueprint(


### PR DESCRIPTION
## Summary
- preview part slot usage alongside power in shop item cards
- compute slot availability when evaluating part installation
- test ItemCard slot preview behaviors

## Testing
- `npx vitest run --reporter=basic` *(fails: auto.victory.spec.tsx timeout)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b59e9e61e88333ab4638699381ddab