### PR TITLE
Allow selling vital ship parts and add restart prompt when fleet invalid

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -145,7 +145,20 @@ export default function EclipseIntegrated(){
     }
     void playEffect('equip');
   }
-  function sellPart(frameId:FrameId, idx:number){ const arr = blueprints[frameId]; if(!arr) return; const part = arr[idx]; if(!part) return; const next = arr.filter((_,i:number)=> i!==idx); const tmp = makeShip(getFrame(frameId), next); if(!tmp.stats.valid) return; const refund = Math.floor((part.cost||0)*0.25); setResources(r=>({...r, credits: r.credits + refund })); updateBlueprint(frameId, () => next); }
+  function sellPart(frameId:FrameId, idx:number){
+    const arr = blueprints[frameId];
+    if(!arr) return;
+    const part = arr[idx];
+    if(!part) return;
+    const next = arr.filter((_,i:number)=> i!==idx);
+    const tmp = makeShip(getFrame(frameId), next);
+    const refund = Math.floor((part.cost||0)*0.25);
+    setResources(r=>({...r, credits: r.credits + refund }));
+    updateBlueprint(frameId, () => next, true);
+    if(!tmp.stats.valid){
+      console.warn('Ship will not participate in combat until power and drive requirements are met.');
+    }
+  }
 
   // ---------- Capacity & build/upgrade ----------
   function buildShip(){ const res = buildI(blueprints as Record<FrameId, Part[]>, resources, tonnage.used, capacity); if(!res) return; setFleet(f=>[...f, res.ship]); setFocused(fleet.length); setResources(r=>({ ...r, credits: r.credits + res.delta.credits, materials: r.materials + res.delta.materials })); }
@@ -338,6 +351,7 @@ export default function EclipseIntegrated(){
           tonnage={tonnage}
           fleetValid={fleetValid}
           startCombat={startCombat}
+          onRestart={resetRun}
         />
       )}
 

--- a/src/__tests__/auto.victory.spec.tsx
+++ b/src/__tests__/auto.victory.spec.tsx
@@ -1,4 +1,4 @@
-import { describe, it } from 'vitest'
+import { describe, it, expect } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
 import App from '../App'
 
@@ -7,6 +7,7 @@ describe('auto combat', () => {
     render(<App />)
     fireEvent.click(screen.getByRole('button', { name: /Easy/i }))
     fireEvent.click(screen.getByRole('button', { name: /Auto/i }))
-    await screen.findByText(/Victory/i, undefined, { timeout: 10000 })
-  })
+    const wins = await screen.findAllByText(/Victory/i, undefined, { timeout: 10000 })
+    expect(wins.length).toBeGreaterThan(0)
+  }, 15000)
 })

--- a/src/__tests__/dock.spec.tsx
+++ b/src/__tests__/dock.spec.tsx
@@ -48,6 +48,7 @@ describe('dock and upgrade visuals', () => {
         tonnage={{used:1, cap:6}}
         fleetValid={true}
         startCombat={()=>{}}
+        onRestart={()=>{}}
       />
     );
     const slotTexts = screen.getAllByText(/⬛ 6→8 slots/);
@@ -59,5 +60,39 @@ describe('dock and upgrade visuals', () => {
     expect(buildBtn).toHaveTextContent('🟢');
     fireEvent.mouseEnter(upgradeBtn);
     expect(screen.getAllByTestId('dock-slot-preview').length).toBeGreaterThan(0);
+  });
+
+  it('offers restart when fleet invalid and broke', () => {
+    const ship = makeShip(getFrame('interceptor'), [] as any);
+    render(
+      <OutpostPage
+        resources={{credits:0, materials:0, science:0}}
+        rerollCost={0}
+        doReroll={()=>{}}
+        research={{Military:1, Grid:1, Nano:1} as any}
+        researchLabel={(t)=>t}
+        canResearch={()=>false}
+        researchTrack={()=>{}}
+        fleet={[ship] as any}
+        focused={0}
+        setFocused={()=>{}}
+        buildShip={()=>{}}
+        upgradeShip={()=>{}}
+        upgradeDock={()=>{}}
+        upgradeLockInfo={()=>null}
+        blueprints={{interceptor:[], cruiser:[], dread:[]}}
+        sellPart={()=>{}}
+        shop={{items:[]}}
+        ghost={()=>({} as any)}
+        buyAndInstall={()=>{}}
+        capacity={{cap:6}}
+        tonnage={{used:1, cap:6}}
+        fleetValid={false}
+        startCombat={()=>{}}
+        onRestart={()=>{}}
+      />
+    );
+    expect(screen.getByText('Fleet inoperable and no credits')).toBeInTheDocument();
+    expect(screen.getByRole('button', {name:'Restart'})).toBeInTheDocument();
   });
 });

--- a/src/pages/OutpostPage.tsx
+++ b/src/pages/OutpostPage.tsx
@@ -33,6 +33,7 @@ export function OutpostPage({
   tonnage,
   fleetValid,
   startCombat,
+  onRestart,
 }:{
   resources:Resources,
   rerollCost:number,
@@ -57,6 +58,7 @@ export function OutpostPage({
   tonnage:{used:number,cap:number},
   fleetValid:boolean,
   startCombat:()=>void,
+  onRestart:()=>void,
 }){
   const focusedShip = fleet[focused];
   const fleetGroups = groupFleet(fleet);
@@ -273,10 +275,19 @@ export function OutpostPage({
 
       {/* Start Combat */}
       <div className="fixed bottom-0 left-0 w-full z-10 p-3 bg-zinc-950/95 backdrop-blur border-t border-zinc-800">
-        <div className="mx-auto max-w-5xl flex items-center gap-2">
+      <div className="mx-auto max-w-5xl flex items-center gap-2">
           <button onClick={()=> fleetValid && startCombat()} className={`flex-1 px-4 py-3 rounded-xl ${fleetValid?'bg-emerald-600':'bg-zinc-700 opacity-60'}`}>Start Combat</button>
-          {!fleet.every(s=>s.stats.valid) && <div className="text-xs text-rose-300">Fix fleet (Source + Drive + ⚡ OK)</div>}
-          {tonnage.used > capacity.cap && <div className="text-xs text-rose-300">Over capacity — expand docks</div>}
+          {(!fleetValid && resources.credits<=0) ? (
+            <>
+              <div className="text-xs text-rose-300">Fleet inoperable and no credits</div>
+              <button onClick={onRestart} className="px-2 py-1 rounded bg-rose-600 text-xs">Restart</button>
+            </>
+          ) : (
+            <>
+              {!fleet.every(s=>s.stats.valid) && <div className="text-xs text-rose-300">Fix fleet (Source + Drive + ⚡ OK)</div>}
+              {tonnage.used > capacity.cap && <div className="text-xs text-rose-300">Over capacity — expand docks</div>}
+            </>
+          )}
         </div>
       </div>
     </>


### PR DESCRIPTION
## Summary
- permit selling blueprint parts even if ship becomes inoperable
- warn and offer restart when fleet is invalid and player has no credits
- cover restart flow and auto-combat victory in tests

## Testing
- `npx vitest run --reporter=json`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b59eb1afd08333b07afe932bb3f830