### PR TITLE
Streamline mobile header and help menu

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -48,6 +48,7 @@ export default function EclipseIntegrated(){
   const [showRules, setShowRules] = useState(false);
   const [showTechs, setShowTechs] = useState(false);
   const [showWin, setShowWin] = useState(false);
+  const [showHelpMenu, setShowHelpMenu] = useState(false);
   const [endless, setEndless] = useState(false);
   const [graceUsed, setGraceUsed] = useState(saved?.graceUsed ?? false);
   const [difficulty, setDifficulty] = useState<null|DifficultyId>(saved?.difficulty ?? null);
@@ -399,8 +400,21 @@ export default function EclipseIntegrated(){
 
       {/* Floating utility buttons */}
       <div className="fixed bottom-3 right-3 z-40 flex flex-col gap-2">
-        <button onClick={()=>setShowTechs(true)} className="px-3 py-2 rounded-full bg-zinc-800 border border-zinc-700 text-xs">🔬 Tech</button>
-        <button onClick={()=>setShowRules(true)} className="px-3 py-2 rounded-full bg-zinc-800 border border-zinc-700 text-xs">❓ Rules</button>
+        <div className="hidden sm:flex flex-col gap-2">
+          <button onClick={()=>setShowTechs(true)} className="px-3 py-2 rounded-full bg-zinc-800 border border-zinc-700 text-xs">🔬 Tech</button>
+          <button onClick={()=>setShowRules(true)} className="px-3 py-2 rounded-full bg-zinc-800 border border-zinc-700 text-xs">❓ Rules</button>
+        </div>
+        <div className="sm:hidden">
+          {showHelpMenu ? (
+            <div className="flex flex-col gap-2">
+              <button onClick={()=>{ setShowTechs(true); setShowHelpMenu(false); }} className="px-3 py-2 rounded-full bg-zinc-800 border border-zinc-700 text-xs">🔬 Tech</button>
+              <button onClick={()=>{ setShowRules(true); setShowHelpMenu(false); }} className="px-3 py-2 rounded-full bg-zinc-800 border border-zinc-700 text-xs">❓ Rules</button>
+              <button onClick={()=>setShowHelpMenu(false)} className="px-3 py-2 rounded-full bg-zinc-800 border border-zinc-700 text-xs">✖</button>
+            </div>
+          ) : (
+            <button onClick={()=>setShowHelpMenu(true)} className="px-3 py-2 rounded-full bg-zinc-800 border border-zinc-700 text-xs">❓</button>
+          )}
+        </div>
       </div>
     </div>
   );

--- a/src/__tests__/resourcebar.spec.tsx
+++ b/src/__tests__/resourcebar.spec.tsx
@@ -1,0 +1,14 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { ResourceBar } from '../components/ui';
+
+describe('resource bar', () => {
+  it('shows condensed capacity and restart control', () => {
+    render(<ResourceBar credits={10} materials={5} science={2} tonnage={{ used:3, cap:4 }} sector={7} onReset={() => {}} />);
+    const capNode = screen.getAllByText('🟢', { exact: false }).find(n => n.textContent?.includes('/'))!;
+    expect(capNode.textContent).toMatch(/3\s*\/\s*4/);
+    const sectorNode = screen.getAllByText('🗺️', { exact: false }).find(n => n.textContent?.match(/7/))!;
+    expect(sectorNode.textContent).toMatch(/7/);
+    expect(screen.getByRole('button', { name: /Restart/i })).toBeInTheDocument();
+  });
+});

--- a/src/components/ui.tsx
+++ b/src/components/ui.tsx
@@ -116,15 +116,14 @@ export function ItemCard({ item, canAfford, onBuy, ghostDelta }:{item:Part, canA
 export function ResourceBar({ credits, materials, science, tonnage, sector, onReset }:{credits:number, materials:number, science:number, tonnage:{used:number,cap:number}, sector:number, onReset:()=>void}){
   const used = tonnage.used, cap = tonnage.cap;
   const over = used>cap;
+  const capIcon = over ? '🔴' : '🟢';
   return (
     <div className="sticky top-0 z-10 bg-zinc-950/95 backdrop-blur border-b border-zinc-800">
-      <div className="mx-auto max-w-5xl p-3 grid grid-cols-1 sm:grid-cols-3 gap-2 text-sm sm:text-base">
-        <div className="px-3 py-2 rounded-lg bg-zinc-900 flex items-center justify-between"><span>💰 <b>{credits}</b> • 🧱 <b>{materials}</b> • 🔬 <b>{science}</b></span></div>
-        <div className={`px-3 py-2 rounded-lg ${over? 'bg-rose-950/50 text-rose-200 ring-1 ring-rose-700/30' : 'bg-emerald-950/50 text-emerald-200 ring-1 ring-emerald-700/20'}`}>
-          ⚓ <b>{used}</b> / <b>{cap}</b>
-          <DockSlots used={used} cap={cap} />
-        </div>
-        <div className="px-3 py-2 rounded-lg bg-zinc-900 flex items-center justify-between">🗺️ Sector <b>{sector}</b> <button onClick={onReset} className="ml-2 px-2 py-1 rounded bg-zinc-800 text-xs">Reset</button></div>
+      <div className="mx-auto max-w-5xl p-2 flex items-center gap-2 flex-wrap text-sm sm:text-base">
+        <div className="px-2 py-1 rounded-lg bg-zinc-900 flex-1 whitespace-nowrap">💰 <b>{credits}</b> • 🧱 <b>{materials}</b> • 🔬 <b>{science}</b></div>
+        <div className={`px-2 py-1 rounded-lg whitespace-nowrap ${over? 'bg-rose-950/50 text-rose-200 ring-1 ring-rose-700/30' : 'bg-emerald-950/50 text-emerald-200 ring-1 ring-emerald-700/20'}`}>{capIcon} <b>{used}</b>/<b>{cap}</b></div>
+        <div className="px-2 py-1 rounded-lg bg-zinc-900 whitespace-nowrap">🗺️ <b>{sector}</b></div>
+        <button onClick={onReset} className="px-2 py-1 rounded bg-zinc-800 text-xs">Restart</button>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- Collapse resource bar into single row with compact tonnage and sector info
- Add mobile `?` menu for Tech and Rules actions
- Cover condensed header with ResourceBar test

## Testing
- `npm test -- --run`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b5a37140508333a98e98ee371d153d