### PR TITLE
feat: restore fleet and dynamic grace rewards

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -238,8 +238,13 @@ export default function EclipseIntegrated(){
         void playEffect('page');
         resetRun();
       } else {
-        setFleet(graceRecoverFleet(blueprints as Record<FrameId, Part[]>));
-        setResources(r=> ensureGraceResources(r));
+        setFleet(graceRecoverFleet(fleet, blueprints as Record<FrameId, Part[]>));
+        const rw = calcRewards(enemyFleet, sector);
+        setResources(r=> ensureGraceResources({
+          credits: r.credits + rw.c,
+          materials: r.materials + rw.m,
+          science: r.science + rw.s
+        }));
         void playEffect('page');
         setMode('OUTPOST');
         setShop({ items: rollInventory(research as Research) });

--- a/src/__tests__/rewards.spec.ts
+++ b/src/__tests__/rewards.spec.ts
@@ -1,14 +1,47 @@
 import { describe, it, expect } from 'vitest'
-import { calcRewards } from '../game/rewards'
+import { calcRewards, graceRecoverFleet, ensureGraceResources } from '../game/rewards'
 import { makeShip, getFrame } from '../game'
 import { PARTS } from '../config/parts'
+import { INITIAL_BLUEPRINTS, INITIAL_RESOURCES } from '../config/defaults'
+import { ECONOMY, calcRewardsForFrameId } from '../config/economy'
 
 describe('rewards', () => {
   it('treats every fifth sector as a boss', () => {
     const enemy = [makeShip(getFrame('interceptor'), [PARTS.sources[0], PARTS.drives[0]])] as any
+    enemy[0].alive = false
     const normal = calcRewards(enemy, 16)
     const boss = calcRewards(enemy, 15)
     expect(boss.s).toBe(normal.s + 1)
     expect(boss.m).toBe(normal.m + 1)
+  })
+
+  it('only counts destroyed ships for rewards', () => {
+    const dead = makeShip(getFrame('interceptor'), [PARTS.sources[0], PARTS.drives[0]]) as any
+    const alive = makeShip(getFrame('interceptor'), [PARTS.sources[0], PARTS.drives[0]]) as any
+    dead.alive = false
+    const rw = calcRewards([dead, alive], 1)
+    const base = calcRewardsForFrameId('interceptor')
+    expect(rw.c).toBe(base.c)
+    expect(rw.m).toBe(base.m)
+    expect(rw.s).toBe(base.s)
+  })
+
+  it('recovers the entire fleet on grace', () => {
+    const fleet = [
+      makeShip(getFrame('interceptor'), INITIAL_BLUEPRINTS.interceptor),
+      makeShip(getFrame('cruiser'), INITIAL_BLUEPRINTS.cruiser)
+    ] as any
+    const recovered = graceRecoverFleet(fleet, INITIAL_BLUEPRINTS)
+    expect(recovered.length).toBe(2)
+    expect(recovered[0].frame.id).toBe('interceptor')
+    expect(recovered[1].frame.id).toBe('cruiser')
+  })
+
+  it('ensures a minimum resource grant based on config', () => {
+    const res = ensureGraceResources({ credits: 0, materials: 0, science: 0 })
+    const minC = Math.max(ECONOMY.buildInterceptor.credits, INITIAL_RESOURCES.credits)
+    const minM = Math.max(ECONOMY.buildInterceptor.materials, INITIAL_RESOURCES.materials)
+    expect(res.credits).toBe(minC)
+    expect(res.materials).toBe(minM)
   })
 })


### PR DESCRIPTION
## Summary
- restore full fleet on grace respawn and award resources for destroyed enemies
- compute grace resource floor from economy/config instead of hard-coded values
- pay partial rewards after defeat and add supporting tests

## Testing
- `npm run test:run`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b5cc14521083338e8e72badf40fc24