### PR TITLE
feat: show future tiers in endless plan

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -378,6 +378,8 @@ export default function EclipseIntegrated(){
           buyAndInstall={buyAndInstall}
           capacity={capacity}
           tonnage={tonnage}
+          sector={sector}
+          endless={endless}
           fleetValid={fleetValid}
           startCombat={startCombat}
           onRestart={resetRun}

--- a/src/__tests__/combatplan.endless.spec.tsx
+++ b/src/__tests__/combatplan.endless.spec.tsx
@@ -1,0 +1,11 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { CombatPlanModal } from '../components/modals'
+
+describe('CombatPlanModal endless mode', () => {
+  it('shows upcoming sectors beyond 10', () => {
+    render(<CombatPlanModal onClose={()=>{}} sector={11} endless={true} />)
+    expect(screen.getByText(/Sector 11/)).toBeInTheDocument()
+    expect(screen.getByText(/Sector 15/)).toBeInTheDocument()
+  })
+})

--- a/src/__tests__/dock.spec.tsx
+++ b/src/__tests__/dock.spec.tsx
@@ -46,6 +46,8 @@ describe('dock and upgrade visuals', () => {
         buyAndInstall={()=>{}}
         capacity={{cap:6}}
         tonnage={{used:1, cap:6}}
+        sector={1}
+        endless={false}
         fleetValid={true}
         startCombat={()=>{}}
         onRestart={()=>{}}
@@ -87,6 +89,8 @@ describe('dock and upgrade visuals', () => {
         buyAndInstall={()=>{}}
         capacity={{cap:6}}
         tonnage={{used:1, cap:6}}
+        sector={1}
+        endless={false}
         fleetValid={false}
         startCombat={()=>{}}
         onRestart={()=>{}}

--- a/src/components/modals.tsx
+++ b/src/components/modals.tsx
@@ -1,6 +1,6 @@
 // React import not required with modern JSX transform
 import { FACTIONS } from '../config/factions'
-import { SECTORS, getBossVariants, getBossFleetFor, getOpponentFaction, ALL_PARTS, makeShip, FRAMES } from '../game'
+import { SECTORS, getBossVariants, getBossFleetFor, getOpponentFaction, ALL_PARTS, makeShip, FRAMES, getSectorSpec } from '../game'
 import { getInitialCapacityForDifficulty } from '../config/difficulty'
 import { BASE_CONFIG } from '../config/game'
 import { CompactShip } from './ui'
@@ -49,13 +49,16 @@ export function RulesModal({ onDismiss }:{ onDismiss:()=>void }){
   );
 }
 
-export function CombatPlanModal({ onClose }:{ onClose:()=>void }){
+export function CombatPlanModal({ onClose, sector, endless }:{ onClose:()=>void, sector:number, endless:boolean }){
+  const plan = endless
+    ? Array.from({length:5}, (_,i)=> getSectorSpec(sector + i))
+    : SECTORS;
   return (
     <div className="fixed inset-0 z-50 flex items-end sm:items-center justify-center p-3 bg-black/70">
       <div className="w-full max-w-lg bg-zinc-900 border border-zinc-700 rounded-2xl p-4">
         <div className="text-lg font-semibold mb-2">Combat Plan</div>
         <div className="text-xs sm:text-sm space-y-1 max-h-[60vh] overflow-y-auto pr-1">
-          {SECTORS.map(s=> (
+          {plan.map(s=> (
             <div key={s.sector} className="px-2 py-1 rounded bg-zinc-950 border border-zinc-800 flex items-start justify-between gap-2">
               <div className="flex-1">
                 <div>Sector {s.sector}{s.boss? ' (Boss)':''}</div>

--- a/src/pages/OutpostPage.tsx
+++ b/src/pages/OutpostPage.tsx
@@ -31,6 +31,8 @@ export function OutpostPage({
   buyAndInstall,
   capacity,
   tonnage,
+  sector,
+  endless,
   fleetValid,
   startCombat,
   onRestart,
@@ -56,6 +58,8 @@ export function OutpostPage({
   buyAndInstall:(part:Part)=>void,
   capacity:{cap:number},
   tonnage:{used:number,cap:number},
+  sector:number,
+  endless:boolean,
   fleetValid:boolean,
   startCombat:()=>void,
   onRestart:()=>void,
@@ -117,7 +121,7 @@ export function OutpostPage({
   }
   return (
     <>
-      {showPlan && <CombatPlanModal onClose={()=>setShowPlan(false)} />}
+      {showPlan && <CombatPlanModal onClose={()=>setShowPlan(false)} sector={sector} endless={endless} />}
 
       <div className="mx-auto max-w-5xl pb-24">
 


### PR DESCRIPTION
## Summary
- show upcoming sector caps in Combat Plan when endless mode is active
- plumb sector/endless state through OutpostPage
- test endless plan rendering and update dock tests

## Testing
- `npx vitest run`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b5d2c75454833380605e55c1f429ba