### PR TITLE
Infer part types from their stats

### DIFF
--- a/src/__tests__/core.spec.ts
+++ b/src/__tests__/core.spec.ts
@@ -6,8 +6,13 @@ import {
   getFrame,
   getSectorSpec,
   SECTORS,
+  isDrive,
+  isWeapon,
+  isComputer,
+  isShield,
+  isHull,
 } from '../game'
-import { PARTS } from '../config/parts'
+import { PARTS, RARE_PARTS, type Part } from '../config/parts'
 
 describe('core helpers', () => {
   it('successThreshold clamps between 2 and 6', () => {
@@ -35,6 +40,57 @@ describe('core helpers', () => {
     // Power overuse invalid
     const s4 = makeShip(frame, [PARTS.drives[1], PARTS.weapons[1]])
     expect(s4.stats.valid).toBe(false)
+  })
+
+  it('counts power from non-source parts with power production', () => {
+    const frame = getFrame('interceptor')
+    const absorption = RARE_PARTS.find(p => p.id === 'absorption')!
+    const s = makeShip(frame, [PARTS.drives[0], absorption])
+    expect(s.stats.powerProd).toBe(4)
+    expect(s.stats.valid).toBe(true)
+  })
+
+  it('recognizes drives by init regardless of category', () => {
+    const frame = getFrame('interceptor')
+    const hybrid: Part = { id: 'bridge', name: 'Command Bridge', init: 1, powerCost: 0, tier: 1, cost: 0, cat: 'Computer', tech_category: 'Grid' }
+    const s = makeShip(frame, [hybrid, PARTS.sources[0]])
+    expect(isDrive(hybrid)).toBe(true)
+    expect(s.drive).toBe(hybrid)
+    expect(s.stats.valid).toBe(true)
+  })
+
+  it('recognizes weapons by dice regardless of category', () => {
+    const frame = getFrame('interceptor')
+    const hybrid: Part = { id: 'spiked_shield', name: 'Spiked Shield', dice: 1, dmgPerHit: 1, powerCost: 0, tier: 1, cost: 0, cat: 'Shield', tech_category: 'Nano', faces: [] }
+    const s = makeShip(frame, [hybrid, PARTS.drives[0], PARTS.sources[0]])
+    expect(isWeapon(hybrid)).toBe(true)
+    expect(s.weapons).toContain(hybrid)
+  })
+
+  it('recognizes computers by aim regardless of category', () => {
+    const frame = getFrame('interceptor')
+    const hybrid: Part = { id: 'targeting_shield', name: 'Targeting Shield', aim: 1, powerCost: 0, tier: 1, cost: 0, cat: 'Shield', tech_category: 'Grid' }
+    const s = makeShip(frame, [hybrid, PARTS.drives[0], PARTS.sources[0]])
+    expect(isComputer(hybrid)).toBe(true)
+    expect(s.computer).toBe(hybrid)
+  })
+
+  it('recognizes shields by shield tier regardless of category', () => {
+    const frame = getFrame('interceptor')
+    const hybrid: Part = { id: 'armored_computer', name: 'Armored Computer', shieldTier: 1, powerCost: 0, tier: 1, cost: 0, cat: 'Computer', tech_category: 'Nano' }
+    const s = makeShip(frame, [hybrid, PARTS.drives[0], PARTS.sources[0]])
+    expect(isShield(hybrid)).toBe(true)
+    expect(s.shield).toBe(hybrid)
+    expect(s.stats.shieldTier).toBe(1)
+  })
+
+  it('recognizes hull parts by extra hull regardless of category', () => {
+    const frame = getFrame('interceptor')
+    const hybrid = RARE_PARTS.find(p => p.id === 'sentient_hull')!
+    const s = makeShip(frame, [hybrid, PARTS.drives[0], PARTS.sources[0]])
+    expect(isHull(hybrid)).toBe(true)
+    expect(s.hullParts).toContain(hybrid)
+    expect(s.stats.hullCap).toBe(2)
   })
 
   it('getSectorSpec scales beyond predefined sectors', () => {

--- a/src/game/ship.ts
+++ b/src/game/ship.ts
@@ -1,12 +1,13 @@
 import { FRAMES, type Frame, type FrameId } from '../config/frames';
 import type { Part } from '../config/parts';
 
-export const isSource = (p:Part)=> p.cat === 'Source';
-export const isDrive = (p:Part)=> p.cat === 'Drive';
-export const isWeapon = (p:Part)=> p.cat === 'Weapon';
-export const isComputer = (p:Part)=> p.cat === 'Computer';
-export const isShield = (p:Part)=> p.cat === 'Shield';
-export const isHull = (p:Part)=> p.cat === 'Hull';
+// Parts may provide their effects even if categorized differently
+export const isSource = (p:Part)=> p.powerProd !== undefined;
+export const isDrive = (p:Part)=> p.init !== undefined;
+export const isWeapon = (p:Part)=> p.dice !== undefined;
+export const isComputer = (p:Part)=> p.aim !== undefined;
+export const isShield = (p:Part)=> p.shieldTier !== undefined;
+export const isHull = (p:Part)=> p.extraHull !== undefined;
 
 // Safe frame lookup to avoid undefined access
 export function getFrame(id: FrameId){


### PR DESCRIPTION
## Summary
- detect computers, shields, and hull parts via `aim`, `shieldTier`, and `extraHull` fields so hybrids work outside their base categories
- exercise hybrid computers, shields, and hull parts in tests to ensure they’re recognized by their stats

## Testing
- `npm test -- --run`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b658a90d548333bd7c50c1a52b657e