### PR TITLE
Fix hull overflow and stack ships in combat

### DIFF
--- a/src/__tests__/fleetRow.spec.tsx
+++ b/src/__tests__/fleetRow.spec.tsx
@@ -1,0 +1,25 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import { describe, it, beforeAll, afterAll, expect } from 'vitest'
+import { FleetRow } from '../components/FleetRow'
+import { makeShip, getFrame, PARTS } from '../game'
+
+describe('FleetRow', () => {
+  let original: PropertyDescriptor | undefined
+  beforeAll(() => {
+    original = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'offsetWidth')
+    Object.defineProperty(HTMLElement.prototype, 'offsetWidth', { configurable: true, value: 200 })
+  })
+  afterAll(() => {
+    if (original) {
+      Object.defineProperty(HTMLElement.prototype, 'offsetWidth', original)
+    }
+  })
+
+  it('groups ships when width is small', async () => {
+    const src = PARTS.sources[0]
+    const drv = PARTS.drives[0]
+    const ships = Array.from({length:5}, () => makeShip(getFrame('interceptor'), [src, drv]) as any)
+    render(<FleetRow ships={ships} side='P' activeIdx={-1} />)
+    await waitFor(() => expect(screen.getByText('×5')).toBeInTheDocument())
+  })
+})

--- a/src/__tests__/fleetRow.spec.tsx
+++ b/src/__tests__/fleetRow.spec.tsx
@@ -22,4 +22,16 @@ describe('FleetRow', () => {
     render(<FleetRow ships={ships} side='P' activeIdx={-1} />)
     await waitFor(() => expect(screen.getByText('×5')).toBeInTheDocument())
   })
+
+  it('removes destroyed ships from stacks', async () => {
+    const src = PARTS.sources[0]
+    const drv = PARTS.drives[0]
+    const ships = Array.from({length:3}, () => makeShip(getFrame('interceptor'), [src, drv]) as any)
+    ships[0].hull = 0
+    ships[0].alive = false
+    Object.defineProperty(HTMLElement.prototype, 'offsetWidth', { configurable: true, value: 150 })
+    render(<FleetRow ships={ships} side='P' activeIdx={-1} />)
+    await waitFor(() => expect(screen.getByText('×2')).toBeInTheDocument())
+    expect(screen.queryByText('×3')).toBeNull()
+  })
 })

--- a/src/__tests__/hull.spec.tsx
+++ b/src/__tests__/hull.spec.tsx
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { CompactShip } from '../components/ui'
+import { makeShip, getFrame, PARTS } from '../game'
+
+describe('CompactShip hull display', () => {
+  it('switches to numeric hull when cap is large', () => {
+    const src = PARTS.sources[0]
+    const drv = PARTS.drives[0]
+    const ship = makeShip(getFrame('interceptor'), [src, drv])
+    ship.stats.hullCap = 25
+    ship.hull = 10
+    render(<CompactShip ship={ship} side="P" active={false} />)
+    expect(screen.getByText('10/25 🤎')).toBeInTheDocument()
+  })
+})

--- a/src/components/FleetRow.tsx
+++ b/src/components/FleetRow.tsx
@@ -1,0 +1,53 @@
+// React import not required with modern JSX transform
+import { useRef, useState, useEffect } from 'react'
+import { CompactShip } from './ui'
+import type { Ship } from '../config/types'
+import { groupFleet } from '../game'
+
+export function FleetRow({ ships, side, activeIdx }:{ ships:Ship[], side:'P'|'E', activeIdx:number }){
+  const ref = useRef<HTMLDivElement>(null)
+  const [width, setWidth] = useState(0)
+
+  useEffect(() => {
+    const measure = () => setWidth(ref.current?.offsetWidth || 0)
+    measure()
+    window.addEventListener('resize', measure)
+    return () => window.removeEventListener('resize', measure)
+  }, [])
+
+  const cardWidth = 112 // approximate width of w-28
+  let groups = ships.map((ship, idx) => ({ ship, count:1, indices:[idx] }))
+
+  if (width && ships.length > 1){
+    const step = (width - cardWidth) / (ships.length - 1)
+    if (step < 50){
+      groups = groupFleet(ships).map(g => {
+        const sorted = [...g.indices].sort((a,b)=> ships[a].hull - ships[b].hull)
+        return { ...g, indices: sorted, ship: ships[sorted[0]] }
+      })
+    }
+  }
+
+  const n = groups.length
+  const step = n>1 && width ? Math.min(cardWidth + 8, (width - cardWidth)/(n-1)) : cardWidth + 8
+
+  return (
+    <div ref={ref} className="relative h-36 w-full">
+      {groups.map((g,i)=>{
+        const stack = Math.min(g.count-1,2)
+        const isActive = g.indices.includes(activeIdx)
+        return (
+          <div key={i} className="absolute top-0" style={{ left: `${i*step}px` }}>
+            {Array.from({length: stack}).map((_,j)=>(
+              <div key={j} className={`pointer-events-none absolute inset-0 rounded-xl border ${side==='P'? 'border-sky-600/60 bg-slate-900':'border-pink-600/60 bg-zinc-900'}`} style={{transform:`translate(${(j+1)*4}px, ${(j+1)*4}px)`}} />
+            ))}
+            {g.count>1 && <div className="absolute -top-2 -left-2 bg-zinc-800 px-1 rounded text-xs">×{g.count}</div>}
+            <CompactShip ship={g.ship} side={side} active={isActive} />
+          </div>
+        )
+      })}
+    </div>
+  )
+}
+
+export default FleetRow

--- a/src/components/FleetRow.tsx
+++ b/src/components/FleetRow.tsx
@@ -16,13 +16,15 @@ export function FleetRow({ ships, side, activeIdx }:{ ships:Ship[], side:'P'|'E'
   }, [])
 
   const cardWidth = 112 // approximate width of w-28
-  let groups = ships.map((ship, idx) => ({ ship, count:1, indices:[idx] }))
+  const alive = ships.map((ship, idx) => ({ ship, idx })).filter(({ ship }) => ship.alive && ship.hull > 0)
+  let groups = alive.map(({ ship, idx }) => ({ ship, count:1, indices:[idx] }))
 
-  if (width && ships.length > 1){
-    const step = (width - cardWidth) / (ships.length - 1)
+  if (width && alive.length > 1){
+    const step = (width - cardWidth) / (alive.length - 1)
     if (step < 50){
-      groups = groupFleet(ships).map(g => {
-        const sorted = [...g.indices].sort((a,b)=> ships[a].hull - ships[b].hull)
+      groups = groupFleet(alive.map(a=>a.ship)).map(g => {
+        const mapped = g.indices.map(i => alive[i].idx)
+        const sorted = [...mapped].sort((a,b)=> ships[a].hull - ships[b].hull)
         return { ...g, indices: sorted, ship: ships[sorted[0]] }
       })
     }

--- a/src/components/ui.tsx
+++ b/src/components/ui.tsx
@@ -12,9 +12,16 @@ export function PowerBadge({use, prod}:{use:number, prod:number}){
   );
 }
 export function HullPips({ current, max }:{current:number, max:number}){
-  const arr = Array.from({length: max});
+  if (max > 20) {
+    return (
+      <div className="flex gap-1 mt-1 text-[10px] sm:text-xs leading-none">
+        {current}/{max} 🤎
+      </div>
+    );
+  }
+  const arr = Array.from({ length: max });
   return (
-    <div className="flex gap-0.5 mt-1 text-[10px] sm:text-xs leading-none">
+    <div className="flex flex-wrap gap-0.5 mt-1 text-[10px] sm:text-xs leading-none">
       {arr.map((_, i) => (
         <span key={i}>{i < current ? '❤️' : '🖤'}</span>
       ))}
@@ -50,14 +57,11 @@ export function CompactShip({ ship, side, active }:{ship:Ship, side:'P'|'E', act
   const weaponParts = ship.parts.filter((p:Part)=> (p.dice||0) > 0 || (p.riftDice||0) > 0);
   return (
     <div className={`relative w-28 sm:w-32 p-2 rounded-xl border shadow-sm ${dead? 'border-zinc-700 bg-zinc-900 opacity-60' : side==='P' ? 'border-sky-600/60 bg-slate-900' : 'border-pink-600/60 bg-zinc-900'} ${active? 'ring-2 ring-amber-400 animate-pulse':''}`}>
-      <div className="flex items-start justify-between">
-        <div
-          className="text-[11px] sm:text-xs font-semibold"
-          title={ship.frame.name}
-        >
-          🟢 {ship.frame.tonnage}
-        </div>
-        <PowerBadge use={ship.stats.powerUse} prod={ship.stats.powerProd} />
+      <div
+        className="text-[11px] sm:text-xs font-semibold"
+        title={ship.frame.name}
+      >
+        🟢 {ship.frame.tonnage}
       </div>
       <div className="mt-0.5 text-[10px] opacity-70">🚀 {ship.stats.init} • 🎯 {ship.stats.aim} • 🛡️ {ship.stats.shieldTier}</div>
       <HullPips current={Math.max(0, ship.hull)} max={ship.stats.hullCap} />

--- a/src/pages/CombatPage.tsx
+++ b/src/pages/CombatPage.tsx
@@ -1,6 +1,6 @@
 // React import not required with modern JSX transform
-import { CompactShip } from '../components/ui'
 import { type Ship, type InitiativeEntry } from '../config/types'
+import { FleetRow } from '../components/FleetRow'
 
 export function CombatPage({
   combatOver,
@@ -47,20 +47,12 @@ export function CombatPage({
           Round {roundNum}{queue[turnPtr]? ` • Next: ${(queue[turnPtr].side==='P'?'P':'E')} ${queue[turnPtr].side==='P'?fleet[queue[turnPtr].idx]?.frame.name:enemyFleet[queue[turnPtr].idx]?.frame.name}`: ''}
         </div>
       </div>
-      <div className="flex gap-2 overflow-x-auto pb-1">
-        {enemyFleet.map((s,i)=> (
-          <CompactShip key={'e'+i} ship={s} side='E' active={!combatOver && queue[turnPtr]?.side==='E' && queue[turnPtr]?.idx===i} />
-        ))}
-      </div>
+      <FleetRow ships={enemyFleet} side='E' activeIdx={!combatOver && queue[turnPtr]?.side==='E' ? queue[turnPtr].idx : -1} />
       {/* Player row */}
       <div className="flex items-center justify-between mt-4 mb-2">
         <div className="text-sm font-semibold">Player</div>
       </div>
-      <div className="flex gap-2 overflow-x-auto pb-1">
-        {fleet.map((s,i)=> (
-          <CompactShip key={'p'+i} ship={s} side='P' active={!combatOver && queue[turnPtr]?.side==='P' && queue[turnPtr]?.idx===i} />
-        ))}
-      </div>
+      <FleetRow ships={fleet} side='P' activeIdx={!combatOver && queue[turnPtr]?.side==='P' ? queue[turnPtr].idx : -1} />
       {/* Mini Log */}
       <div className="mt-3 p-2 rounded bg-zinc-900 text-xs sm:text-sm min-h-[56px]">
         {log.slice(-5).map((ln,i)=>(<div key={i} className={i===log.length-1? 'font-medium' : 'opacity-80'}>{ln}</div>))}


### PR DESCRIPTION
## Summary
- wrap hull hearts and show numeric hull when large
- remove power info from compact ship view
- overlap fleets and only stack ships when space runs out
- add test ensuring fleet rows collapse into stacks on narrow widths

## Testing
- `npm test` *(fails: slots.spec.tsx)*
- `npx vitest run src/__tests__/fleetRow.spec.tsx`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b6746638a48333a10638f000052ae6