### PR TITLE
Fix boss fleet configs after part updates

### DIFF
--- a/src/__tests__/newparts.spec.ts
+++ b/src/__tests__/newparts.spec.ts
@@ -32,8 +32,8 @@ describe('New part mechanics', () => {
     const frame = getFrame('interceptor')
     const src = PARTS.sources[0]
     const drv = PARTS.drives[0]
-    const nova = PARTS.weapons.find(p=>p.id==='nova_battery')!
-    const ship = makeShip(frame, [src, drv, nova, nova, PARTS.hull[0]])
+    const plasma = PARTS.weapons.find(p=>p.id==='plasma_battery')!
+    const ship = makeShip(frame, [src, drv, plasma, plasma, PARTS.hull[0]])
     expect(ship.stats.valid).toBe(false)
   })
 })

--- a/src/__tests__/slots.spec.tsx
+++ b/src/__tests__/slots.spec.tsx
@@ -17,7 +17,7 @@ async function toOutpost(faction: RegExp) {
 
 describe('slot displays', () => {
   it('shows slot usage in ItemCard', () => {
-    const cluster = PARTS.weapons.find(p => p.id === 'cluster_missiles')!;
+    const cluster = PARTS.weapons.find(p => p.id === 'plasma_cluster')!;
     render(<ItemCard item={cluster} canAfford={true} ghostDelta={null as any} onBuy={() => {}} />);
     expect(screen.getByText(/2 slots/i)).toBeInTheDocument();
   });

--- a/src/config/factions.ts
+++ b/src/config/factions.ts
@@ -100,7 +100,7 @@ const BOSS_FLEETS: Record<FactionId, { five: BossFleetSpec; ten: BossFleetSpec }
     ]},
     ten: { sector:10, name:'Quantum Phalanx', ships:[
       { frame:'dread', parts:['zero_point','quantum_source','transition_drive','sentient_ai','neutrino','omega','rift_cannon','monolith_plating'] },
-      { frame:'cruiser', parts:['tachyon_source','quantum_source','warp_drive','neutrino','omega','rift_cannon','reinforced'] },
+      { frame:'cruiser', parts:['tachyon_source','quantum_source','warp_drive','neutrino','omega','rift_cannon','improved'] },
     ]},
   },
   warmongers: {
@@ -110,7 +110,7 @@ const BOSS_FLEETS: Record<FactionId, { five: BossFleetSpec; ten: BossFleetSpec }
     ]},
     ten: { sector:10, name:'Crimson Armada', ships:[
       { frame:'dread', parts:['zero_point','quantum_source','transition_drive','rift_cannon','neutrino','omega','adamantine'] },
-      { frame:'cruiser', parts:['tachyon_source','quantum_source','warp_drive','antimatter','gluon','phase','reinforced'] },
+      { frame:'cruiser', parts:['tachyon_source','quantum_source','warp_drive','antimatter','gluon','phase','improved'] },
     ]},
   },
   industrialists: {
@@ -119,8 +119,8 @@ const BOSS_FLEETS: Record<FactionId, { five: BossFleetSpec; ten: BossFleetSpec }
       { frame:'interceptor', parts:['fusion_source','ion_thruster','composite','positron','plasma','absorption'] },
     ]},
     ten: { sector:10, name:'Cartel Citadel', ships:[
-      { frame:'dread', parts:['zero_point','quantum_source','transition_drive','monolith_plating','reinforced','omega','plasma_array','quantum_cpu','singularity'] },
-      { frame:'cruiser', parts:['tachyon_source','quantum_source','warp_drive','reinforced','phase','plasma_array','quantum_cpu'] },
+      { frame:'dread', parts:['zero_point','quantum_source','transition_drive','monolith_plating','improved','omega','plasma_array','quantum_cpu','singularity'] },
+      { frame:'cruiser', parts:['tachyon_source','quantum_source','warp_drive','improved','phase','plasma_array','quantum_cpu'] },
     ]},
   },
   raiders: {
@@ -150,7 +150,7 @@ const BOSS_FLEETS: Record<FactionId, { five: BossFleetSpec; ten: BossFleetSpec }
     ]},
     ten: { sector:10, name:'Enduring Mass', ships:[
       { frame:'dread', parts:['zero_point','quantum_source','transition_drive','plasma_cluster','neutrino','omega','auto_repair','adamantine'] },
-      { frame:'cruiser', parts:['tachyon_source','warp_drive','nova_battery','gluon','phase','auto_repair'] },
+      { frame:'cruiser', parts:['tachyon_source','warp_drive','plasma_battery','gluon','phase','auto_repair'] },
     ]},
   },
 };


### PR DESCRIPTION
## Summary
- replace deprecated `reinforced` and `nova_battery` IDs in boss fleets
- update tests to use new `plasma_*` weapons

## Testing
- `npm run test:run`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b67a6f9534833387578c8104f8d432