### PR TITLE
Display ship slot layouts in combat view

### DIFF
--- a/src/__tests__/frameSlots.spec.tsx
+++ b/src/__tests__/frameSlots.spec.tsx
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { CompactShip } from '../components/ui'
+import { makeShip, getFrame, PARTS } from '../game'
+
+// Ensure ship frame slots render filled and empty boxes based on installed parts
+describe('CompactShip frame slot display', () => {
+  it('fills slots according to part slot usage', () => {
+    const src = PARTS.sources[0]
+    const drv = PARTS.drives[0]
+    const bigWeapon = PARTS.weapons.find(p => p.id === 'plasma_battery')!
+    const ship = makeShip(getFrame('interceptor'), [src, drv, bigWeapon])
+    render(<CompactShip ship={ship} side="P" active={false} />)
+    const used = ship.parts.reduce((a, p) => a + (p.slots || 1), 0)
+    expect(screen.getAllByTestId('frame-slot-filled').length).toBe(used)
+    expect(screen.getAllByTestId('frame-slot-empty').length).toBe(ship.frame.tiles - used)
+  })
+})


### PR DESCRIPTION
## Summary
- show frame-specific slot grid with icons for installed parts
- add tests ensuring slot counts match parts used

## Testing
- `npm run test:run`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b9e2b40a908333a2981b0c0c731334