### PR TITLE
Seed cruiser and dreadnought blueprints on first upgrade

### DIFF
--- a/src/__tests__/hangar.spec.ts
+++ b/src/__tests__/hangar.spec.ts
@@ -13,14 +13,41 @@ describe('dock expansion', () => {
 })
 
 describe('ship upgrade', () => {
-  it('retains existing parts when upgrading', () => {
-    const extra = PARTS.hull[2]
-    const base = [PARTS.sources[0], PARTS.drives[0], PARTS.weapons[0], PARTS.computers[0], extra]
-    const ship = makeShip(getFrame('interceptor'), base)
-    const fleet = [ship] as any
-    const blueprints: Record<FrameId, typeof base> = { interceptor: base, cruiser: [], dread: [] } as any
-    const result = upgradeShipAt(0, fleet, blueprints, { credits: 100, materials: 100 }, { Military: 3 }, { cap: 10 }, 1)
-    expect(result?.upgraded.parts.map(p=>p.id)).toEqual(ship.parts.map(p=>p.id))
-    expect(result?.blueprints.cruiser.map(p=>p.id)).toEqual(ship.parts.map(p=>p.id))
+  it('seeds cruiser blueprint from first interceptor upgrade', () => {
+    const interceptorParts = [PARTS.sources[0], PARTS.drives[0]]
+    const fleet = [makeShip(getFrame('interceptor'), interceptorParts)] as any
+    const blueprints: Record<FrameId, typeof interceptorParts> = { interceptor: interceptorParts, cruiser: [], dread: [] } as any
+    const result = upgradeShipAt(0, fleet, blueprints, { credits: 1000, materials: 1000 }, { Military: 3 }, { cap: 999 }, 0)
+    expect(result?.upgraded.parts.map(p=>p.id)).toEqual(interceptorParts.map(p=>p.id))
+    expect(result?.blueprints.cruiser.map(p=>p.id)).toEqual(interceptorParts.map(p=>p.id))
+  })
+
+  it('applies updated blueprints to subsequent upgrades', () => {
+    const interceptorParts = [PARTS.sources[0], PARTS.drives[0]]
+    let blueprints: Record<FrameId, typeof interceptorParts> = { interceptor: interceptorParts, cruiser: [], dread: [] } as any
+    const fleet = [
+      makeShip(getFrame('interceptor'), interceptorParts),
+      makeShip(getFrame('interceptor'), interceptorParts)
+    ] as any
+
+    const first = upgradeShipAt(0, fleet, blueprints, { credits: 1000, materials: 1000 }, { Military: 3 }, { cap: 999 }, 0)
+    if(first){
+      blueprints = first.blueprints
+      fleet[0] = first.upgraded
+    }
+
+    blueprints.cruiser = [...blueprints.cruiser, PARTS.weapons[2]]
+
+    const second = upgradeShipAt(1, fleet, blueprints, { credits: 1000, materials: 1000 }, { Military: 3 }, { cap: 999 }, 0)
+    expect(second?.upgraded.parts.map(p=>p.id)).toEqual(blueprints.cruiser.map(p=>p.id))
+  })
+
+  it('seeds dreadnought blueprint from first cruiser upgrade', () => {
+    const cruiserParts = [PARTS.sources[0], PARTS.drives[0]]
+    const fleet = [makeShip(getFrame('cruiser'), cruiserParts)] as any
+    const blueprints: Record<FrameId, typeof cruiserParts> = { interceptor: cruiserParts, cruiser: cruiserParts, dread: [] } as any
+    const result = upgradeShipAt(0, fleet, blueprints, { credits: 1000, materials: 1000 }, { Military: 3 }, { cap: 999 }, 0)
+    expect(result?.upgraded.parts.map(p=>p.id)).toEqual(cruiserParts.map(p=>p.id))
+    expect(result?.blueprints.dread.map(p=>p.id)).toEqual(cruiserParts.map(p=>p.id))
   })
 })

--- a/src/__tests__/slots.spec.tsx
+++ b/src/__tests__/slots.spec.tsx
@@ -10,7 +10,7 @@ async function toOutpost(faction: RegExp) {
   fireEvent.click(screen.getByRole('button', { name: /Easy/i }));
   fireEvent.click(screen.getByRole('button', { name: /Let’s go/i }));
   fireEvent.click(screen.getByRole('button', { name: /Auto/i }));
-  await screen.findByText(/^Victory$/i, undefined, { timeout: 10000 });
+  await screen.findByRole('button', { name: /Return to Outpost/i }, { timeout: 20000 });
   fireEvent.click(screen.getByRole('button', { name: /Return to Outpost/i }));
   await screen.findByText(/Outpost Inventory/i);
 }
@@ -25,7 +25,7 @@ describe('slot displays', () => {
   it('shows slots in Class Blueprint header for Cruiser', async () => {
     await toOutpost(/Crimson Vanguard/i);
     const header = await screen.findByText(/Class Blueprint — Cruiser/i);
-    expect(header.textContent).toMatch(/4\/8/);
+    expect(header.textContent).toMatch(/0\/8/);
   }, 20000);
 
   it('previews slot usage in ItemCard ghost delta', () => {

--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -12,8 +12,8 @@ export const INITIAL_CAPACITY = { cap: 3 } as const;
 
 export const INITIAL_BLUEPRINTS: Record<FrameId, Part[]> = {
   interceptor: [PARTS.sources[0], PARTS.drives[0], PARTS.weapons[0], PARTS.computers[0]],
-  cruiser:     [PARTS.sources[1], PARTS.drives[1], PARTS.weapons[0], PARTS.shields[0]],
-  dread:       [PARTS.sources[1], PARTS.drives[1], PARTS.weapons[0], PARTS.weapons[0], PARTS.shields[0]],
+  cruiser:     [],
+  dread:       [],
 };
 
 

--- a/src/game/hangar.ts
+++ b/src/game/hangar.ts
@@ -54,9 +54,12 @@ export function upgradeShipAt(
   if((tonnageUsed + deltaTons) > capacity.cap) return null;
   if(resources.credits < cost.c || resources.materials < cost.m) return null;
   const nextFrame = getFrame(nextId);
-  const carry = [...s.parts];
+  const nextBlueprints = { ...blueprints } as Record<FrameId, Part[]>;
+  if(nextBlueprints[nextId].length === 0){
+    nextBlueprints[nextId] = [ ...s.parts ];
+  }
+  const carry = [ ...nextBlueprints[nextId] ];
   const upgraded = makeShip(nextFrame, carry);
-  const nextBlueprints = { ...blueprints, [nextId]: carry } as Record<FrameId, Part[]>;
   return { idx, upgraded: upgraded as unknown as Ship, blueprints: nextBlueprints, delta:{ credits: -cost.c, materials: -cost.m } };
 }
 

--- a/src/game/setup.ts
+++ b/src/game/setup.ts
@@ -47,8 +47,8 @@ export function initNewRun({ difficulty, faction }: NewRunParams): NewRunState{
 
   const classBlueprints: Record<FrameId, Part[]> = {
     interceptor: [ ...f.config.blueprints.interceptor ],
-    cruiser: [ ...f.config.blueprints.cruiser ],
-    dread: [ ...f.config.blueprints.dread ],
+    cruiser: [],
+    dread: [],
   };
 
   const startFrameId = f.config.startingFrame as FrameId;


### PR DESCRIPTION
## Summary
- remove default cruiser and dreadnought loadouts so blueprints start empty
- seed next-class blueprint from the upgrading ship when first upgrading
- expand tests for blueprint seeding and update slots test for new cruiser defaults

## Testing
- `npm run test:run`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ba0d2274d48333b9b7c26c00799581