### PR TITLE
feat(sp): make lives explicit in shared/difficulty.ts (easy/medium=1,…

### DIFF
--- a/coding_agents/sp_lives_refactor_plan.md
+++ b/coding_agents/sp_lives_refactor_plan.md
@@ -1,0 +1,40 @@
+# SP Lives Refactor — Plan
+
+Date: 2025-09-06
+Branch: feature/sp-lives-config
+Owner: coding_agents
+
+## Goal
+Fix the single‑player "Hard shows immediate loss" confusion by making lives an explicit difficulty property, and by using only the lives counter to decide defeat. Remove implicit coupling to a "defeat policy" for SP flow while keeping a compatibility shim for any existing references.
+
+## Why
+- The current code infers lives from `getDefeatPolicy(difficulty)`; Hard maps to `reset`, which yielded `0` lives and could be interpreted as an instant loss. Lives should be a first‑class setting to avoid ambiguity.
+- Using only `livesRemaining` to determine end of run is clearer and matches the UI (hearts counter).
+
+## Changes
+- shared/difficulty.ts
+  - Add `lives: number` to `DifficultySpec`.
+  - Set: Easy=1, Medium=1, Hard=0.
+  - Add `getStartingLives(difficulty)`.
+  - Keep `getDefeatPolicy()` as a shim that derives from lives (lives>0 ⇒ grace, else reset).
+- App.tsx
+  - Initialization: replace policy‑based lives with `getStartingLives()`.
+  - Defeat resolution: rely solely on `livesRemaining` (remove policy check).
+  - Back‑compat: preserve old `graceUsed` save support.
+
+## Tests
+- New: `src/__tests__/sp_hard_lives_config.spec.ts`
+  - Asserts lives per difficulty and policy shim mapping.
+- Existing suites pass (multiplayer unaffected).
+
+## Risks / Mitigations
+- Old code paths reading `getDefeatPolicy()` still work due to shim.
+- Saves with `graceUsed` continue to load via back‑compat branch.
+
+## Acceptance Criteria
+- Selecting Hard no longer implies an immediate run loss; the player starts with 0 lives and only loses the run upon an actual defeat.
+- Easy/Medium initialize with 1 life.
+
+## Follow‑ups (optional)
+- Consider showing a small tooltip in StartPage for difficulties describing starting lives explicitly.
+

--- a/shared/difficulty.ts
+++ b/shared/difficulty.ts
@@ -6,15 +6,16 @@ export type DefeatPolicy = 'reset' | 'grace';
 
 export type DifficultySpec = {
   startingShips: number;
-  defeatPolicy: DefeatPolicy;
+  // Explicit lives configuration; when 0 there is no respawn (hard mode)
+  lives: number;
   baseRerollCost: number;
   startingFrame?: FrameId;
 };
 
 const DIFFICULTY_SPECS: Record<DifficultyId, DifficultySpec> = {
-  easy: { startingShips: 5, defeatPolicy: 'grace', baseRerollCost: 5 },
-  medium: { startingShips: 3, defeatPolicy: 'grace', baseRerollCost: 8 },
-  hard: { startingShips: 3, defeatPolicy: 'reset', baseRerollCost: 12 },
+  easy: { startingShips: 5, lives: 1, baseRerollCost: 5 },
+  medium: { startingShips: 3, lives: 1, baseRerollCost: 8 },
+  hard: { startingShips: 3, lives: 0, baseRerollCost: 12 },
 };
 
 export function getDifficultySpec(difficulty: DifficultyId): DifficultySpec {
@@ -25,12 +26,17 @@ export function getStartingShipCount(difficulty: DifficultyId): number {
   return DIFFICULTY_SPECS[difficulty].startingShips;
 }
 
+// Backward-compat shim: derive defeat policy from lives
 export function getDefeatPolicy(difficulty: DifficultyId): DefeatPolicy {
-  return DIFFICULTY_SPECS[difficulty].defeatPolicy;
+  return DIFFICULTY_SPECS[difficulty].lives > 0 ? 'grace' : 'reset';
 }
 
 export function getBaseRerollCost(difficulty: DifficultyId): number {
   return DIFFICULTY_SPECS[difficulty].baseRerollCost;
+}
+
+export function getStartingLives(difficulty: DifficultyId): number {
+  return DIFFICULTY_SPECS[difficulty].lives;
 }
 
 export function getInitialCapacityForDifficulty(difficulty: DifficultyId, startingFrameId?: FrameId): number {
@@ -40,4 +46,3 @@ export function getInitialCapacityForDifficulty(difficulty: DifficultyId, starti
   const required = spec.startingShips * perShipTonnage;
   return Math.max(INITIAL_CAPACITY.cap, required + 1);
 }
-

--- a/src/__tests__/sp_hard_lives_config.spec.ts
+++ b/src/__tests__/sp_hard_lives_config.spec.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from 'vitest'
+import { getStartingLives, getDefeatPolicy } from '../../shared/difficulty'
+
+describe('Single-player lives configuration', () => {
+  it('provides explicit starting lives per difficulty', () => {
+    expect(getStartingLives('easy')).toBe(1)
+    expect(getStartingLives('medium')).toBe(1)
+    expect(getStartingLives('hard')).toBe(0)
+  })
+
+  it('defeat policy derives from lives for backward compatibility', () => {
+    expect(getDefeatPolicy('easy')).toBe('grace')
+    expect(getDefeatPolicy('medium')).toBe('grace')
+    expect(getDefeatPolicy('hard')).toBe('reset')
+  })
+})
+


### PR DESCRIPTION
… hard=0); add getStartingLives(); App uses lives-only defeat logic; tests for config; add plan doc coding_agents/sp_lives_refactor_plan.md