### PR TITLE
UI: CompactShip slot sizing – better fit for weapon dice

### DIFF
--- a/src/components/ui.tsx
+++ b/src/components/ui.tsx
@@ -148,9 +148,11 @@ export function ShipFrameSlots({ ship, side, active }: { ship: Ship, side: 'P' |
               <div
                 key={i}
                 data-testid={label ? 'frame-slot-filled' : 'frame-slot-empty'}
-                className={`w-6 h-6 sm:w-7 sm:h-7 text-[11px] sm:text-xs grid place-items-center rounded ${glow} ${activeGlow}`}
+                className={`w-7 h-7 sm:w-8 sm:h-8 text-[10px] sm:text-[11px] md:text-xs leading-none grid place-items-center rounded ${glow} ${activeGlow}`}
               >
-                {label}
+                <span className={`${label.length > 3 ? 'scale-[.90] sm:scale-[.95]' : ''} inline-block`}>
+                  {label}
+                </span>
               </div>
             ))}
           </div>


### PR DESCRIPTION
This PR improves the readability and fit of weapon dice (and other effect symbols) inside CompactShip frame slots on both mobile and desktop.

Changes
- Increase slot size slightly for headroom: `w-7 h-7` → `sm:w-8 h-8`.
- Reduce base font size and tighten line-height to prevent spillover.
- Add a tiny responsive downscale for dense labels (many symbols) so they fit without truncation.
- Keep glow/active styles unchanged; only layout/typography adjusted.

Why
Emoji render larger than text and were overfilling the slot squares, especially on mobile or when multiple symbols appeared (e.g., 🎲💥 combos). The new sizing keeps a consistent look and ensures labels fit cleanly.

Testing
- Verified locally in Vite dev server across iPhone SE/Pro and desktop breakpoints.
- Checked hull, shields, rift dice, and mixed part labels for overlap and clipping.

Follow‑ups
- If we prefer smaller emojis but not larger squares, I can invert the change (reduce font more, keep slots at previous size). For now this balances readability and fit.
