### PR TITLE
fix(ui): help menu opens Rules and Tech modals

### DIFF
--- a/coding_agents/subagents/planning_agent.md
+++ b/coding_agents/subagents/planning_agent.md
@@ -81,3 +81,38 @@
 ### Follow-ups
 - Consider small-history view (last 3 rounds) with tabs.
 - Optional toggle to show compact summary vs. ship grid.
+
+## Plan Entry — Help Menu Rules/Tech Modals
+
+- Outcome: Players can open the Rules and Tech List modals from the bottom-right help buttons on all screens; Rules modal layers above floating UI and allows text selection.
+
+- Acceptance criteria:
+  - Clicking the “❓ Rules” button opens the Rules modal (“How to Play”).
+  - Clicking the “🔬 Tech” button opens the Tech List modal.
+  - Both modals can be dismissed via their internal buttons and do not interfere with each other.
+  - The Rules modal overlays above floating help buttons (no overlap or click-through issues).
+  - Lint, targeted tests, and build remain green.
+
+- Risks & rollback:
+  - Risk: Prop API change on `GameShell` breaks call sites. Mitigation: update `GameRoot` at the same time; changes are localized.
+  - Rollback: Revert the `GameShell`/`GameRoot` prop changes and the test file.
+
+- Test list (must fail first):
+  1) UI: Clicking “❓ Rules” opens the Rules modal (help_menu_modals.spec.tsx).
+  2) UI: Clicking “🔬 Tech” opens the Tech List modal (same test file).
+
+---
+
+### Implementation Steps
+- Add `onOpenRules` and `onOpenTechs` props to `GameShell`.
+- Wire them in `GameRoot` to `setShowRules(true)` and `setShowTechs(true)`.
+- Update help buttons to call the open handlers (not the close handlers).
+- Bump `RulesModal` z-index from `z-40` to `z-50` to match other modals.
+- Add focused test: `src/__tests__/help_menu_modals.spec.tsx`.
+
+### Decision Log
+- Standardized modal layering at `z-50` to prevent overlap with floating help UI.
+- Kept existing close handlers for internal modal buttons; only the external help triggers were incorrect.
+
+### Follow-ups
+- Consider adding backdrop click-to-close behavior for consistency across modals.

--- a/src/GameRoot.tsx
+++ b/src/GameRoot.tsx
@@ -386,7 +386,9 @@ export default function EclipseIntegrated(){
     <GameShell
       showRules={showRules}
       onDismissRules={dismissRules}
+      onOpenRules={()=>setShowRules(true)}
       showTechs={showTechs}
+      onOpenTechs={()=>setShowTechs(true)}
       onCloseTechs={()=>setShowTechs(false)}
       showWin={showWin}
       onRestartWin={()=>{ setShowWin(false); resetRun() }}

--- a/src/__tests__/help_menu_modals.spec.tsx
+++ b/src/__tests__/help_menu_modals.spec.tsx
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import App from '../App'
+
+describe('Help menu modals', () => {
+  it('opens Rules and Tech modals from help buttons', async () => {
+    localStorage.clear()
+    render(<App />)
+
+    // Enter a run (Easy) and dismiss the initial Rules prompt
+    fireEvent.click(screen.getByRole('button', { name: /Easy/i }))
+    const letsGo = await screen.findByRole('button', { name: /Let’s go/i })
+    fireEvent.click(letsGo)
+
+    // Desktop help buttons should be visible (sm breakpoint)
+    const rulesBtn = await screen.findByRole('button', { name: /❓ Rules/i })
+    fireEvent.click(rulesBtn)
+    expect(await screen.findByText(/How to Play/i)).toBeInTheDocument()
+
+    // Dismiss rules
+    fireEvent.click(screen.getByRole('button', { name: /Let’s go/i }))
+
+    // Open Tech list from help button
+    const techBtn = await screen.findByRole('button', { name: /🔬 Tech/i })
+    fireEvent.click(techBtn)
+    expect(await screen.findByText(/Tech List/i)).toBeInTheDocument()
+  }, 15000)
+})
+

--- a/src/components/GameShell.tsx
+++ b/src/components/GameShell.tsx
@@ -37,7 +37,9 @@ export type CombatProps = {
 export function GameShell({
   showRules,
   onDismissRules,
+  onOpenRules,
   showTechs,
+  onOpenTechs,
   onCloseTechs,
   showWin,
   onRestartWin,
@@ -50,7 +52,9 @@ export function GameShell({
 }: {
   showRules: boolean
   onDismissRules: () => void
+  onOpenRules: () => void
   showTechs: boolean
+  onOpenTechs: () => void
   onCloseTechs: () => void
   showWin: boolean
   onRestartWin: () => void
@@ -78,14 +82,14 @@ export function GameShell({
 
       <div className="fixed bottom-3 right-3 z-40 flex flex-col gap-2">
         <div className="hidden sm:flex flex-col gap-2">
-          <button onClick={onCloseTechs} className="px-3 py-2 rounded-full bg-zinc-800 border border-zinc-700 text-xs">🔬 Tech</button>
-          <button onClick={onDismissRules} className="px-3 py-2 rounded-full bg-zinc-800 border border-zinc-700 text-xs">❓ Rules</button>
+          <button onClick={onOpenTechs} className="px-3 py-2 rounded-full bg-zinc-800 border border-zinc-700 text-xs">🔬 Tech</button>
+          <button onClick={onOpenRules} className="px-3 py-2 rounded-full bg-zinc-800 border border-zinc-700 text-xs">❓ Rules</button>
         </div>
         <div className="sm:hidden">
           {showHelpMenu ? (
             <div className="flex flex-col gap-2">
-              <button onClick={()=>{ onCloseTechs(); setShowHelpMenu(false) }} className="px-3 py-2 rounded-full bg-zinc-800 border border-zinc-700 text-xs">🔬 Tech</button>
-              <button onClick={()=>{ onDismissRules(); setShowHelpMenu(false) }} className="px-3 py-2 rounded-full bg-zinc-800 border border-zinc-700 text-xs">❓ Rules</button>
+              <button onClick={()=>{ onOpenTechs(); setShowHelpMenu(false) }} className="px-3 py-2 rounded-full bg-zinc-800 border border-zinc-700 text-xs">🔬 Tech</button>
+              <button onClick={()=>{ onOpenRules(); setShowHelpMenu(false) }} className="px-3 py-2 rounded-full bg-zinc-800 border border-zinc-700 text-xs">❓ Rules</button>
               <button onClick={()=>setShowHelpMenu(false)} className="px-3 py-2 rounded-full bg-zinc-800 border border-zinc-700 text-xs">✖</button>
             </div>
           ) : (

--- a/src/components/modals.tsx
+++ b/src/components/modals.tsx
@@ -33,7 +33,7 @@ export function RulesModal({ onDismiss }:{ onDismiss:()=>void }){
   const dockStart = getInitialCapacityForDifficulty('easy', BASE_CONFIG.startingFrame);
   const dockCircles = '🟢'.repeat(dockStart);
   return (
-    <div className="fixed inset-0 z-40 flex items-end sm:items-center justify-center p-3 bg-black/60">
+    <div className="fixed inset-0 z-50 flex items-end sm:items-center justify-center p-3 bg-black/60">
       <div className="w-full max-w-lg bg-zinc-900 border border-zinc-700 rounded-2xl p-4 shadow-xl">
         <div className="text-lg font-semibold mb-2">How to Play</div>
         <div className="text-sm space-y-3 max-h-[60vh] overflow-y-auto pr-1">


### PR DESCRIPTION
This fixes the help-menu buttons so they actually open the Rules and Tech modals, and aligns modal layering.\n\nChanges\n- GameShell: add `onOpenRules`, `onOpenTechs`; wire help buttons to open handlers\n- GameRoot: provide open handlers via `setShowRules(true)`, `setShowTechs(true)`\n- RulesModal: raise overlay from `z-40` to `z-50`\n- Tests: add `help_menu_modals.spec.tsx` (fail-first verified, now green)\n\nValidation\n- Lint: ok (warnings only)\n- Build: ok\n- Targeted test: `npx vitest run src/__tests__/help_menu_modals.spec.tsx` passes\n\nAcceptance criteria\n- Clicking "❓ Rules" opens the Rules modal ("How to Play")\n- Clicking "🔬 Tech" opens the Tech List modal\n- Modals overlay above floating UI and can be dismissed via internal buttons\n\nRisk/rollback\n- Localized prop change confined to `GameShell` + `GameRoot`. Revert these files and the test to roll back.
