### PR TITLE
MP: deduct credits/materials for outpost actions (persist to server)

### DIFF
--- a/src/__tests__/mp_outpost_resources_persist.spec.ts
+++ b/src/__tests__/mp_outpost_resources_persist.spec.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi } from 'vitest'
+import React from 'react'
+import { render } from '@testing-library/react'
+import { useOutpostHandlers } from '../hooks/useOutpostHandlers'
+
+// Sanity: building/interacting in MP should persist resource deltas via updateGameState
+describe('MP outpost resource persistence', () => {
+  it('build/upgrade/dock call updateGameState with new resources', () => {
+    const multi = { updateGameState: vi.fn() }
+    const base = {
+      resources: { credits: 100, materials: 100, science: 0 },
+      research: { Military: 1, Grid: 1, Nano: 1 },
+      blueprints: { interceptor: [], cruiser: [], dread: [] } as Record<'interceptor'|'cruiser'|'dread', any[]>,
+      fleet: [],
+      capacity: { cap: 10 },
+      tonnageUsed: 0,
+      focusedIndex: 0,
+      rerollCost: 8,
+      shopVersion: 0,
+    }
+    function Harness(){
+      const [state, setState] = React.useState(base)
+      const handlers = useOutpostHandlers({
+        gameMode: 'multiplayer',
+        state,
+        setters: {
+          setResources: (r:any)=> setState(s=>({ ...s, resources:r })),
+          setResearch: (r:any)=> setState(s=>({ ...s, research:r })),
+          setBlueprints: (bp:any)=> setState(s=>({ ...s, blueprints:bp })),
+          setFleet: (f:any)=> setState(s=>({ ...s, fleet:f })),
+          setCapacity: (c:any)=> setState(s=>({ ...s, capacity:c })),
+          setFocused: (_:number)=>{},
+          setRerollCost: (_:number)=>{},
+          setShopVersion: (_:number)=>{},
+          setShop: (_:any)=>{},
+          setLastEffects: (_:any)=>{},
+        },
+        multi: multi as any,
+      })
+      // Invoke actions when instructed via global flags
+      ;(window as any).__mpHandlers = handlers
+      return null
+    }
+    render(React.createElement(Harness))
+    let handlers = (window as any).__mpHandlers as ReturnType<typeof useOutpostHandlers>
+    handlers.buildShip()
+    expect(multi.updateGameState).toHaveBeenCalled()
+    const [{ resources }] = (multi.updateGameState as any).mock.calls.at(-1)
+    expect(resources.credits).toBeLessThan(100)
+    // Grab latest handlers after state update (re-render)
+    handlers = (window as any).__mpHandlers as ReturnType<typeof useOutpostHandlers>
+    handlers.upgradeDock()
+    const [{ resources: r2 }] = (multi.updateGameState as any).mock.calls.at(-1)
+    expect(r2.credits).toBeLessThan(100)
+  })
+})

--- a/src/hooks/useOutpostHandlers.ts
+++ b/src/hooks/useOutpostHandlers.ts
@@ -88,24 +88,39 @@ export function useOutpostHandlers(params: UseOutpostHandlersParams): OutpostHan
   }, [gameMode, economyMods, state, setters])
 
   const buyAndInstall = useCallback((part: Part) => {
-    apply(OutpostIntents.buyAndInstall(part))
+    const r = apply(OutpostIntents.buyAndInstall(part))
+    if (r && gameMode === 'multiplayer' && multi?.updateGameState) {
+      try { multi.updateGameState({ resources: r.next.resources }) } catch { /* noop */ }
+    }
     sound?.('equip')
   }, [apply, sound])
 
   const sellPart = useCallback((frameId: FrameId, idx: number) => {
-    apply(OutpostIntents.sellPart(frameId, idx))
+    const r = apply(OutpostIntents.sellPart(frameId, idx))
+    if (r && gameMode === 'multiplayer' && multi?.updateGameState) {
+      try { multi.updateGameState({ resources: r.next.resources }) } catch { /* noop */ }
+    }
   }, [apply])
 
   const buildShip = useCallback(() => {
-    apply(OutpostIntents.buildShip())
+    const r = apply(OutpostIntents.buildShip())
+    if (r && gameMode === 'multiplayer' && multi?.updateGameState) {
+      try { multi.updateGameState({ resources: r.next.resources }) } catch { /* noop */ }
+    }
   }, [apply])
 
   const upgradeShip = useCallback((idx: number) => {
-    apply(OutpostIntents.upgradeShip(idx))
+    const r = apply(OutpostIntents.upgradeShip(idx))
+    if (r && gameMode === 'multiplayer' && multi?.updateGameState) {
+      try { multi.updateGameState({ resources: r.next.resources }) } catch { /* noop */ }
+    }
   }, [apply])
 
   const upgradeDock = useCallback(() => {
-    apply(OutpostIntents.upgradeDock())
+    const r = apply(OutpostIntents.upgradeDock())
+    if (r && gameMode === 'multiplayer' && multi?.updateGameState) {
+      try { multi.updateGameState({ resources: r.next.resources }) } catch { /* noop */ }
+    }
     sound?.('dock')
   }, [apply, sound])
 


### PR DESCRIPTION
Fixes a multiplayer regression where outpost actions (build/upgrade/dock/buy/sell) did not persist resource deductions to the server, leaving credits unchanged and allowing repeated purchases.

Changes
- useOutpostHandlers: after applying engine commands, call `updateGameState` in MP for buy/sell/build/upgrade/dock with the updated `resources`.
- Kept existing MP persistence for reroll and research.
- Added targeted test: `mp_outpost_resources_persist.spec.ts` to verify that these actions trigger server persistence.

Why this works
- Outpost UI in MP displays server resources via `getMyResources`; without persisting, server-side credits never changed, so affordability checks stayed permissive. Persisting closes the loop and keeps UI/engine in sync.

Risk/Scope
- Only touches MP path in handlers; SP unaffected.
- Writes only `resources` to the server (no blueprints/fleet payload).
