### PR TITLE
Enhance battle log messaging and mobile UI

### DIFF
--- a/src/__tests__/progress_log.spec.ts
+++ b/src/__tests__/progress_log.spec.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { recordWin, evaluateUnlocks, loadProgress, DEFAULT_PROGRESS, type SavedRun } from '../game/storage';
+
+// Tests for narrative progress log entries using full faction names
+
+describe('progress log entries', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    DEFAULT_PROGRESS.log = [];
+  });
+
+  it('records victories with faction names and colorful text', () => {
+    const research = { Military: 1, Grid: 1, Nano: 1 };
+    recordWin('industrialists', 'easy', research, []);
+    const prog = loadProgress();
+    const entry = prog.log[prog.log.length - 1];
+    expect(entry).toMatch(/Helios Cartel/);
+    expect(entry).toMatch(/Triumph|Victory/);
+  });
+
+  it('logs faction unlocks with full names', () => {
+    const seeded = {
+      factions: {
+        scientists: { unlocked: false, difficulties: [] },
+        warmongers: { unlocked: false, difficulties: [] },
+        industrialists: { unlocked: true, difficulties: [] },
+        raiders: { unlocked: false, difficulties: [] },
+        timekeepers: { unlocked: false, difficulties: [] },
+        collective: { unlocked: false, difficulties: [] },
+      },
+      log: [],
+    };
+    localStorage.setItem('eclipse-progress', JSON.stringify(seeded));
+    const run: Partial<SavedRun> = { research: { Military: 3, Grid: 3, Nano: 3 }, fleet: [] };
+    evaluateUnlocks(run);
+    const prog = loadProgress();
+    expect(prog.log.some(l => /Consortium of Scholars/.test(l))).toBe(true);
+  });
+});

--- a/src/game/storage.ts
+++ b/src/game/storage.ts
@@ -92,7 +92,7 @@ export function evaluateUnlocks(run: PartialRun | null, victory = false): Progre
     const pf = prog.factions[f.id];
     if (!pf.unlocked && f.unlock && f.unlock(ctx)) {
       pf.unlocked = true;
-      prog.log.push(`Unlocked ${f.id}`);
+      prog.log.push(`Your achievements have caught the attention of the ${f.name}. Their faction is now available.`);
     }
   }
   saveProgress(prog);
@@ -126,7 +126,9 @@ export function recordWin(fid: FactionId, diff: DifficultyId, research: Research
   if (pf && !pf.difficulties.includes(diff)) {
     pf.difficulties.push(diff);
   }
-  prog.log.push(`Won as ${fid} on ${diff}`);
+  const name = getFaction(fid).name;
+  const diffName = diff.charAt(0).toUpperCase() + diff.slice(1);
+  prog.log.push(`Victory for the ${name} on ${diffName} difficulty.`);
   saveProgress(prog);
   evaluateUnlocks({ research, fleet }, true);
 }

--- a/src/pages/StartPage.tsx
+++ b/src/pages/StartPage.tsx
@@ -183,15 +183,16 @@ export default function StartPage({
 
         {/* Battle Log Modal */}
         {showLog && (
-          <div role="dialog" aria-modal="true" className="fixed inset-0 z-50 flex items-center justify-center">
+          <div role="dialog" aria-modal="true" className="fixed inset-0 z-50 flex items-center justify-center p-4">
             <button aria-label="Close" onClick={()=>setShowLog(false)} className="absolute inset-0 bg-black/50" />
-            <div className="relative w-full max-w-md mx-auto bg-zinc-950 border border-white/10 rounded-2xl p-4">
-              <div className="text-lg font-semibold">Battle Log</div>
-              <ul className="text-sm mt-2 space-y-1">
-                {progress.log.length===0 && <li>No battles yet.</li>}
-                {progress.log.map((l,i)=>(<li key={i}>{l}</li>))}
+            <div className="relative w-full max-w-md mx-auto bg-zinc-950 border border-white/10 rounded-2xl p-4 max-h-[80vh] flex flex-col">
+              <button aria-label="Close Battle Log" onClick={()=>setShowLog(false)} className="absolute top-2 right-2 text-zinc-400 hover:text-zinc-200">✕</button>
+              <div className="text-lg font-semibold mb-2">Battle Log</div>
+              <ul className="flex-1 overflow-y-auto pr-2 text-sm font-mono space-y-2">
+                {progress.log.length===0 && <li className="text-zinc-400">No battles yet.</li>}
+                {progress.log.map((l,i)=>(<li key={i} className="border-l-2 border-emerald-600 pl-2">{l}</li>))}
               </ul>
-              <div className="mt-3"><button className="px-3 py-2 rounded-xl bg-zinc-800" onClick={()=>setShowLog(false)}>Close</button></div>
+              <div className="mt-3 text-right"><button className="px-3 py-2 rounded-xl bg-zinc-800" onClick={()=>setShowLog(false)}>Close</button></div>
             </div>
           </div>
         )}


### PR DESCRIPTION
## Summary
- Use faction names and colorful phrasing for progress log wins and unlocks
- Add mobile-friendly battle log modal with scroll and close button
- Test that progress log entries include faction names

## Testing
- `npx eslint src/game/storage.ts src/pages/StartPage.tsx src/__tests__/progress_log.spec.ts`
- `npm run test:run -- src/__tests__/progress_log.spec.ts`
- `npm run test:run -- src/__tests__/startpage.spec.tsx`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c2d99942fc8333804c4b12d0802b9b