### PR TITLE
Add cheat code entry and handlers

### DIFF
--- a/src/__tests__/cheats.spec.ts
+++ b/src/__tests__/cheats.spec.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { loadProgress } from '../game/storage';
+import { applyCheatCode } from '../game/cheats';
+
+describe('cheat codes', () => {
+  const seeded = {
+    factions: {
+      scientists: { unlocked: false, difficulties: [] },
+      warmongers: { unlocked: false, difficulties: [] },
+      industrialists: { unlocked: true, difficulties: [] },
+      raiders: { unlocked: false, difficulties: [] },
+      timekeepers: { unlocked: false, difficulties: [] },
+      collective: { unlocked: false, difficulties: [] },
+    },
+    log: [],
+  };
+
+  beforeEach(() => {
+    localStorage.clear();
+    localStorage.setItem('eclipse-progress', JSON.stringify(seeded));
+  });
+
+  it('unlocks raiders via forplunder', () => {
+    expect(loadProgress().factions.raiders.unlocked).toBe(false);
+    applyCheatCode('forplunder');
+    expect(loadProgress().factions.raiders.unlocked).toBe(true);
+  });
+
+  it('unlocks hard difficulty for existing factions with truechallenge', () => {
+    applyCheatCode('truechallenge');
+    const prog = loadProgress();
+    expect(prog.factions.industrialists.difficulties).toContain('medium');
+    expect(prog.factions.scientists.difficulties).toEqual([]);
+  });
+
+  it('unlocks all factions with mercenary', () => {
+    applyCheatCode('mercenary');
+    const prog = loadProgress();
+    for (const f of Object.values(prog.factions)) {
+      expect(f.unlocked).toBe(true);
+    }
+  });
+});

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -1,0 +1,126 @@
+import { useState } from 'react';
+import { applyCheatCode } from '../game/cheats';
+
+export default function SettingsModal({
+  starEnabled,
+  setStarEnabled,
+  starDensity,
+  setStarDensity,
+  userReducedMotion,
+  setUserReducedMotion,
+  onClose,
+  onCheatApplied,
+}: {
+  starEnabled: boolean;
+  setStarEnabled: (v: boolean) => void;
+  starDensity: 'low' | 'medium' | 'high';
+  setStarDensity: (d: 'low' | 'medium' | 'high') => void;
+  userReducedMotion: boolean;
+  setUserReducedMotion: (v: boolean) => void;
+  onClose: () => void;
+  onCheatApplied: () => void;
+}) {
+  const [cheat, setCheat] = useState('');
+
+  return (
+    <div role="dialog" aria-modal="true" className="fixed inset-0 z-50 flex items-center justify-center">
+      <button aria-label="Close" onClick={onClose} className="absolute inset-0 bg-black/50" />
+      <div className="relative w-full max-w-md mx-auto bg-zinc-950 border border-white/10 rounded-2xl p-4">
+        <div className="text-lg font-semibold">Settings</div>
+        <div className="mt-3 space-y-4 text-sm">
+          <div className="flex items-center justify-between">
+            <span>Starfield</span>
+            <button
+              className={`px-3 py-1 rounded-full border ${starEnabled ? 'bg-emerald-700 border-emerald-500' : 'bg-zinc-800 border-white/10'}`}
+              onClick={() => {
+                const v = !starEnabled;
+                setStarEnabled(v);
+                try {
+                  localStorage.setItem('ui-starfield-enabled', String(v));
+                  window.dispatchEvent(new Event('starfield-settings-changed'));
+                } catch {
+                  void 0;
+                }
+              }}
+              aria-pressed={starEnabled}
+            >
+              {starEnabled ? 'On' : 'Off'}
+            </button>
+          </div>
+          <div>
+            <div className="mb-2">Star Density</div>
+            <div className="grid grid-cols-3 gap-2">
+              {(['low', 'medium', 'high'] as const).map((d) => (
+                <button
+                  key={d}
+                  className={`px-3 py-2 rounded-xl border ${starDensity === d ? 'bg-white/10 border-emerald-500' : 'bg-zinc-900 border-white/10'}`}
+                  aria-pressed={starDensity === d}
+                  onClick={() => {
+                    setStarDensity(d);
+                    try {
+                      localStorage.setItem('ui-starfield-density', d);
+                      window.dispatchEvent(new Event('starfield-settings-changed'));
+                    } catch {
+                      void 0;
+                    }
+                  }}
+                >
+                  {d[0].toUpperCase() + d.slice(1)}
+                </button>
+              ))}
+            </div>
+          </div>
+          <div className="flex items-center justify-between">
+            <span>Reduced Motion</span>
+            <button
+              className={`px-3 py-1 rounded-full border ${userReducedMotion ? 'bg-zinc-800 border-white/10' : 'bg-emerald-700 border-emerald-500'}`}
+              onClick={() => {
+                const v = !userReducedMotion;
+                setUserReducedMotion(v);
+                try {
+                  localStorage.setItem('ui-reduced-motion', String(v));
+                  window.dispatchEvent(new Event('starfield-settings-changed'));
+                } catch {
+                  void 0;
+                }
+              }}
+              aria-pressed={userReducedMotion}
+            >
+              {userReducedMotion ? 'On' : 'Off'}
+            </button>
+          </div>
+          <form
+            onSubmit={(e) => {
+              e.preventDefault();
+              if (applyCheatCode(cheat.trim())) {
+                onCheatApplied();
+              }
+              setCheat('');
+            }}
+          >
+            <label htmlFor="cheat" className="block mb-2">
+              Coded Signal
+            </label>
+            <div className="flex gap-2">
+              <input
+                id="cheat"
+                value={cheat}
+                onChange={(e) => setCheat(e.target.value)}
+                className="flex-1 px-3 py-2 rounded-xl bg-zinc-900 border border-white/10"
+              />
+              <button type="submit" className="px-3 py-2 rounded-xl bg-zinc-800">
+                Send
+              </button>
+            </div>
+          </form>
+        </div>
+        <div className="mt-4 text-right">
+          <button className="px-3 py-2 rounded-xl bg-zinc-800" onClick={onClose}>
+            Close
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+

--- a/src/game/cheats.ts
+++ b/src/game/cheats.ts
@@ -1,0 +1,46 @@
+import { loadProgress, saveProgress, type Progress } from './storage';
+
+export type CheatHandler = (p: Progress) => void;
+
+const CHEATS: Record<string, CheatHandler> = {
+  mercenary: (p) => {
+    for (const f of Object.values(p.factions)) {
+      f.unlocked = true;
+    }
+  },
+  forscience: (p) => {
+    p.factions.scientists.unlocked = true;
+  },
+  forglory: (p) => {
+    p.factions.warmongers.unlocked = true;
+  },
+  forprofit: (p) => {
+    p.factions.industrialists.unlocked = true;
+  },
+  forplunder: (p) => {
+    p.factions.raiders.unlocked = true;
+  },
+  fortime: (p) => {
+    p.factions.timekeepers.unlocked = true;
+  },
+  forswarm: (p) => {
+    p.factions.collective.unlocked = true;
+  },
+  truechallenge: (p) => {
+    for (const f of Object.values(p.factions)) {
+      if (f.unlocked) {
+        if (!f.difficulties.includes('easy')) f.difficulties.push('easy');
+        if (!f.difficulties.includes('medium')) f.difficulties.push('medium');
+      }
+    }
+  },
+};
+
+export function applyCheatCode(code: string): boolean {
+  const action = CHEATS[code.toLowerCase()];
+  if (!action) return false;
+  const prog = loadProgress();
+  action(prog);
+  saveProgress(prog);
+  return true;
+}


### PR DESCRIPTION
## Summary
- Add cheat code helpers to unlock factions or hard mode
- Expose "Coded Signal" input in settings modal to apply codes
- Break out settings into standalone component and refresh progress from storage

## Testing
- `npm run test:run -- src/__tests__/startpage.spec.tsx`
- `npm run test:run -- src/__tests__/cheats.spec.ts`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c30edeb4a48333802348d7fa40f0ac