### PR TITLE
Fix tutorial faction to always Helios Cartel

### DIFF
--- a/src/GameRoot.tsx
+++ b/src/GameRoot.tsx
@@ -448,7 +448,7 @@ export default function EclipseIntegrated(){
     openVersusOnHome,
     currentRoomId,
     onNewRun: newRun,
-    onStartTutorial: (f)=> newRunTutorial(f as FactionId),
+            onStartTutorial: () => newRunTutorial(),
     onContinue: handleContinue,
     onGoMultiplayer: handleGoMultiplayer,
     onGoPublic: () => handleGoPublic(),

--- a/src/__tests__/tutorial_faction.spec.ts
+++ b/src/__tests__/tutorial_faction.spec.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect, vi } from 'vitest';
+import useRunManagement from '../hooks/useRunManagement';
+
+describe('tutorial faction', () => {
+  it('uses Helios Cartel regardless of selected faction', () => {
+    const setters = {
+      setDifficulty: vi.fn(),
+      setFaction: vi.fn(),
+      setOpponent: vi.fn(),
+      setShowNewRun: vi.fn(),
+      playEffect: vi.fn(),
+      setEndless: vi.fn(),
+      setLivesRemaining: vi.fn(),
+      setResources: vi.fn(),
+      setCapacity: vi.fn(),
+      setResearch: vi.fn(),
+      setRerollCost: vi.fn(),
+      setBaseRerollCost: vi.fn(),
+      setSector: vi.fn(),
+      setBlueprints: vi.fn(),
+      setFleet: vi.fn(),
+      setFocused: vi.fn(),
+      setShop: vi.fn(),
+      startFirstCombat: vi.fn(),
+      clearRunState: vi.fn(),
+      setShowRules: vi.fn(),
+    } as any;
+    const { newRunTutorial } = useRunManagement(setters);
+    newRunTutorial();
+    expect(setters.setFaction).toHaveBeenCalledWith('industrialists');
+  });
+});

--- a/src/hooks/useRunManagement.ts
+++ b/src/hooks/useRunManagement.ts
@@ -57,9 +57,10 @@ export function useRunManagement(params: {
     params.setShowRules?.(true)
   }
 
-  function newRunTutorial(pick: FactionId){
-    // Start tutorial on Easy
+  function newRunTutorial(){
+    // Start tutorial on Easy with the Helios Cartel to ensure economy matches guidance
     const diff: DifficultyId = 'easy'
+    const pick: FactionId = 'industrialists'
     p.clearRunState()
     p.setDifficulty(diff)
     p.setFaction(pick)

--- a/src/lib/renderPreGame.ts
+++ b/src/lib/renderPreGame.ts
@@ -19,7 +19,7 @@ export type PreGameRouterProps = {
   currentRoomId: Id<'rooms'> | null
   // handlers
   onNewRun: (diff: DifficultyId, faction: FactionId) => void
-  onStartTutorial?: (faction: FactionId) => void
+  onStartTutorial?: () => void
   onContinue: () => void
   onGoMultiplayer: (mode?: 'menu'|'create'|'join'|'public', opts?: { public?: boolean }) => void
   onGoPublic: () => void

--- a/src/pages/StartPage.tsx
+++ b/src/pages/StartPage.tsx
@@ -17,7 +17,7 @@ export default function StartPage({
   initialLaunchTab,
 }: {
   onNewRun: (diff: DifficultyId, faction: FactionId) => void;
-  onStartTutorial?: (faction: FactionId) => void;
+  onStartTutorial?: () => void;
   onContinue?: () => void;
   onMultiplayer?: (mode?: 'menu' | 'create' | 'join' | 'public') => void;
   initialShowLaunch?: boolean;
@@ -163,9 +163,9 @@ export default function StartPage({
                   {tutorialEligible && onStartTutorial ? (
                     <div>
                       <div className="text-sm opacity-80 mb-2">New? Start with a short guided tutorial.</div>
-                      <div className="mt-2 text-sm opacity-80">Faction: <span className="font-medium">{FACTIONS.find(f=>f.id===faction)?.name}</span></div>
+                      <div className="mt-2 text-sm opacity-80">Faction: <span className="font-medium">{FACTIONS.find(f=>f.id==='industrialists')?.name}</span></div>
                       <div className="mt-3">
-                        <button className="w-full px-3 py-3 rounded-xl bg-emerald-600 hover:bg-emerald-500" onClick={()=>{ onStartTutorial(faction); setShowLaunch(false); }}>
+                        <button className="w-full px-3 py-3 rounded-xl bg-emerald-600 hover:bg-emerald-500" onClick={()=>{ onStartTutorial(); setShowLaunch(false); }}>
                           Start Tutorial
                         </button>
                       </div>


### PR DESCRIPTION
## Summary
- force tutorial runs to use Helios Cartel faction
- adjust StartPage to show Helios Cartel when launching tutorial
- add test covering tutorial faction selection

## Testing
- `npx vitest run src/__tests__/tutorial_faction.spec.ts`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c38d8c0c988333986f347ab2ba616a