### PR TITLE
Scale tutorial enemy fleet per combat

### DIFF
--- a/src/__tests__/tutorial_enemy_softening.spec.ts
+++ b/src/__tests__/tutorial_enemy_softening.spec.ts
@@ -2,18 +2,40 @@ import { describe, it, expect } from 'vitest'
 import { buildEnemyFleet } from '../game/enemy'
 import { enable as tutEnable, setStep as tutSet, disable as tutDisable } from '../tutorial/state'
 
+const basePartIds = ['fusion_source','fusion_drive','plasma']
+
 describe('tutorial enemy softening', () => {
-  it('uses a basic interceptor during tutorial and normal pacing afterwards', () => {
+  it('ramps interceptor count each combat during tutorial and falls back afterwards', () => {
     localStorage.clear()
-    tutEnable(); tutSet('intro-combat' as any)
-    const soft = buildEnemyFleet(1)
-    expect(soft).toHaveLength(1)
-    expect(soft[0].frame.id).toBe('interceptor')
+    tutEnable();
+
+    tutSet('intro-combat' as any)
+    const first = buildEnemyFleet(1)
+    expect(first).toHaveLength(1)
+    first.forEach(s => {
+      expect(s.frame.id).toBe('interceptor')
+      expect(s.parts.map(p=>p.id)).toEqual(basePartIds)
+    })
+
+    tutSet('combat-2' as any)
+    const second = buildEnemyFleet(1)
+    expect(second).toHaveLength(2)
+    second.forEach(s => {
+      expect(s.frame.id).toBe('interceptor')
+      expect(s.parts.map(p=>p.id)).toEqual(basePartIds)
+    })
+
+    tutSet('combat-3' as any)
+    const third = buildEnemyFleet(1)
+    expect(third).toHaveLength(3)
+    third.forEach(s => {
+      expect(s.frame.id).toBe('interceptor')
+      expect(s.parts.map(p=>p.id)).toEqual(basePartIds)
+    })
+
     // Finish tutorial
     tutDisable()
     const normal = buildEnemyFleet(1)
-    // Normal pacing allows multiple ships and different frames
     expect(normal.length).toBeGreaterThanOrEqual(1)
   })
 })
-

--- a/src/game/enemy.ts
+++ b/src/game/enemy.ts
@@ -8,6 +8,7 @@ import type { Rng } from '../engine/rng'
 import { fromMathRandom } from '../engine/rng'
 import { getOpponentFaction } from './setup';
 import { isEnabled as isTutorialEnabled } from '../tutorial/state'
+import { buildTutorialEnemyFleet } from '../tutorial/enemy'
 
 const BOSS_VARIANTS: Record<number, BossVariant[]> = {
   5: [
@@ -102,11 +103,10 @@ export function randomEnemyPartsFor(frame:Frame, scienceCap:number, boss:boolean
 }
 
 export function buildEnemyFleet(sector:number, rng?: Rng): Ship[]{
-  // Tutorial: always fight a basic Interceptor with no extra hull/specials
+  // Tutorial: build a fleet based on the current step
   try {
     if (isTutorialEnabled()) {
-      const parts = [PARTS.sources[0], PARTS.drives[0], PARTS.weapons[0]]
-      return [ makeShip(FRAMES.interceptor, parts) ] as unknown as Ship[]
+      return buildTutorialEnemyFleet()
     }
   } catch { /* ignore and fall through */ }
   const spec = getSectorSpec(sector);

--- a/src/tutorial/enemy.ts
+++ b/src/tutorial/enemy.ts
@@ -1,0 +1,17 @@
+import { FRAMES } from '../../shared/frames'
+import { PARTS } from '../../shared/parts'
+import type { Ship } from '../../shared/types'
+import { makeShip } from '../game/ship'
+import { getStep } from './state'
+
+const BASE_PARTS = [PARTS.sources[0], PARTS.drives[0], PARTS.weapons[0]]
+
+export function buildTutorialEnemyFleet(): Ship[] {
+  const step = getStep()
+  const count = step === 'combat-2' ? 2 : step === 'intro-combat' ? 1 : 3
+  const ships: Ship[] = [] as unknown as Ship[]
+  for (let i = 0; i < count; i++) {
+    ships.push(makeShip(FRAMES.interceptor, BASE_PARTS) as unknown as Ship)
+  }
+  return ships
+}


### PR DESCRIPTION
## Summary
- extract tutorial enemy generation into `src/tutorial/enemy.ts`
- call new tutorial builder from main enemy generator
- ramp tutorial interceptor count from 1 to 3 across combats

## Testing
- `npm run lint`
- `npm run test:run src/__tests__/tutorial_enemy_softening.spec.ts`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c3906c30dc83339359f32f9320037c