### PR TITLE
feat: enhance tutorial enemy scaling

### DIFF
--- a/src/__tests__/tutorial_enemy_softening.spec.ts
+++ b/src/__tests__/tutorial_enemy_softening.spec.ts
@@ -3,12 +3,25 @@ import { buildEnemyFleet } from '../game/enemy'
 import { enable as tutEnable, setStep as tutSet, disable as tutDisable } from '../tutorial/state'
 
 describe('tutorial enemy softening', () => {
-  it('uses a basic interceptor during tutorial and normal pacing afterwards', () => {
+  it('scales interceptor count during tutorial and falls back afterwards', () => {
     localStorage.clear()
-    tutEnable(); tutSet('intro-combat' as any)
-    const soft = buildEnemyFleet(1)
-    expect(soft).toHaveLength(1)
-    expect(soft[0].frame.id).toBe('interceptor')
+    tutEnable();
+    tutSet('intro-combat' as any)
+
+    const round1 = buildEnemyFleet(1)
+    expect(round1).toHaveLength(1)
+    expect(round1[0].frame.id).toBe('interceptor')
+    expect(round1[0].parts).toHaveLength(3)
+
+    const round2 = buildEnemyFleet(2)
+    expect(round2).toHaveLength(2)
+    expect(round2.every(s => s.frame.id === 'interceptor')).toBe(true)
+    expect(round2.every(s => s.parts.length === 3)).toBe(true)
+
+    const round4 = buildEnemyFleet(4)
+    expect(round4).toHaveLength(3)
+    expect(round4.every(s => s.frame.id === 'interceptor')).toBe(true)
+
     // Finish tutorial
     tutDisable()
     const normal = buildEnemyFleet(1)

--- a/src/game/enemy.ts
+++ b/src/game/enemy.ts
@@ -8,6 +8,7 @@ import type { Rng } from '../engine/rng'
 import { fromMathRandom } from '../engine/rng'
 import { getOpponentFaction } from './setup';
 import { isEnabled as isTutorialEnabled } from '../tutorial/state'
+import { buildTutorialEnemyFleet } from '../tutorial/enemy'
 
 const BOSS_VARIANTS: Record<number, BossVariant[]> = {
   5: [
@@ -102,11 +103,10 @@ export function randomEnemyPartsFor(frame:Frame, scienceCap:number, boss:boolean
 }
 
 export function buildEnemyFleet(sector:number, rng?: Rng): Ship[]{
-  // Tutorial: always fight a basic Interceptor with no extra hull/specials
+  // Tutorial: delegate to simplified generator
   try {
     if (isTutorialEnabled()) {
-      const parts = [PARTS.sources[0], PARTS.drives[0], PARTS.weapons[0]]
-      return [ makeShip(FRAMES.interceptor, parts) ] as unknown as Ship[]
+      return buildTutorialEnemyFleet(sector)
     }
   } catch { /* ignore and fall through */ }
   const spec = getSectorSpec(sector);

--- a/src/tutorial/enemy.ts
+++ b/src/tutorial/enemy.ts
@@ -1,0 +1,10 @@
+import { FRAMES } from '../../shared/frames';
+import { PARTS } from '../../shared/parts';
+import type { Ship } from '../../shared/types';
+import { makeShip } from '../game/ship';
+
+export function buildTutorialEnemyFleet(round: number): Ship[] {
+  const count = Math.min(Math.max(round, 1), 3);
+  const baseParts = [PARTS.sources[0], PARTS.drives[0], PARTS.weapons[0]];
+  return Array.from({ length: count }, () => makeShip(FRAMES.interceptor, [...baseParts]) as unknown as Ship);
+}


### PR DESCRIPTION
## Summary
- extract tutorial enemy generation into dedicated module
- scale tutorial interceptor count by round, up to three ships
- test tutorial fleet scaling and normal fleet behavior

## Testing
- `npm run test:run -- src/__tests__/tutorial_enemy_softening.spec.ts`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c3906c30dc83339359f32f9320037c