### PR TITLE
Show price on unavailable outpost parts

### DIFF
--- a/coding_agents/subagents/planning_agent.md
+++ b/coding_agents/subagents/planning_agent.md
@@ -310,3 +310,18 @@
 ### Follow-ups
 - Overflow/pause menu for Restart/Resign (separate slice).
 - Resource HUD compaction (separate slice).
+
+## Plan Entry — Outpost No-Slot Price Display
+
+- Outcome: Disabled shop buttons show the part cost even when no slot is available.
+- Acceptance criteria:
+  - ItemCard renders `No Slot (X¢)` when slotOk is false.
+  - A test fails first verifying price included in disabled button.
+  - Lint, targeted test, and build stay green.
+
+- Risks & rollback:
+  - Risk: longer button label may wrap. Mitigation: compact card still fits.
+  - Rollback: revert ItemCard label change.
+
+- Test list (must fail first):
+  1) `itemcard_no_slot_price.spec.tsx` ensures price is visible alongside `No Slot`.

--- a/src/__tests__/itemcard_no_slot_price.spec.tsx
+++ b/src/__tests__/itemcard_no_slot_price.spec.tsx
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { ItemCard } from '../components/ui'
+import type { Part } from '../../shared/parts'
+import type { GhostDelta } from '../../shared/types'
+
+describe('ItemCard', () => {
+  it('shows price when disabled for slot', () => {
+    const part: Part = { id: 'p1', name: 'Test Part', tier: 1, cost: 123, tech_category: 'Military', cat: 'Hull', slots: 1 }
+    const ghost: GhostDelta = {
+      targetName: 'ship',
+      use: 0,
+      prod: 0,
+      valid: true,
+      slotsUsed: 2,
+      slotCap: 1,
+      slotOk: false,
+      initBefore: 0,
+      initAfter: 0,
+      initDelta: 0,
+      hullBefore: 0,
+      hullAfter: 0,
+      hullDelta: 0,
+    }
+    render(
+      <ItemCard item={part} price={part.cost} canAfford={true} onBuy={() => {}} ghostDelta={ghost} />
+    )
+    const btn = screen.getByRole('button', { name: /No Slot/i })
+    expect(btn.textContent).toContain('123¢')
+  })
+})

--- a/src/components/ui.tsx
+++ b/src/components/ui.tsx
@@ -87,7 +87,13 @@ export function ItemCard({ item, price, canAfford, onBuy, ghostDelta, compact }:
         </div>
       )}
       <div className="mt-2 flex gap-2">
-        <button disabled={disabled} onClick={onBuy} className={`flex-1 px-3 py-2 rounded-lg text-sm sm:text-base ${!disabled? 'bg-emerald-600 hover:bg-emerald-500 active:scale-[.99]':'bg-zinc-700 opacity-60'}`}>{disabledForSlots? 'No Slot' : `Buy (${cost}¢)`}</button>
+        <button
+          disabled={disabled}
+          onClick={onBuy}
+          className={`flex-1 px-3 py-2 rounded-lg text-sm sm:text-base ${!disabled ? 'bg-emerald-600 hover:bg-emerald-500 active:scale-[.99]' : 'bg-zinc-700 opacity-60'}`}
+        >
+          {disabledForSlots ? `No Slot (${cost}¢)` : `Buy (${cost}¢)`}
+        </button>
         <button aria-label="Part info" onClick={()=>setShowInfo(v=>!v)} className="px-3 py-2 rounded-lg bg-zinc-900 border border-zinc-700">?</button>
       </div>
       {showInfo && (


### PR DESCRIPTION
## Summary
- Display part cost on disabled outpost shop buttons (e.g., `No Slot (20¢)`)
- Document plan entry for this UI tweak
- Add unit test ensuring cost remains visible when slots are full

## Testing
- `npm run test:run -- src/__tests__/itemcard_no_slot_price.spec.tsx`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c4a583b570833381a2b6e7c0b8feff