### PR TITLE
Enable tutorial by default for first-time visitors

### DIFF
--- a/coding_agents/subagents/planning_agent.md
+++ b/coding_agents/subagents/planning_agent.md
@@ -325,3 +325,18 @@
 
 - Test list (must fail first):
   1) `itemcard_no_slot_price.spec.tsx` ensures price is visible alongside `No Slot`.
+## Plan Entry — Tutorial Enabled by Default
+
+- Outcome: First-time players see the tutorial enabled automatically.
+
+- Acceptance criteria:
+  - With no existing tutorial state in localStorage, `isEnabled()` returns true.
+  - Settings modal shows the tutorial toggle as "On" on first visit.
+  - Lint, targeted tests, and build stay green.
+
+- Risks & rollback:
+  - Risk: Corrupt or missing localStorage could cause unexpected tutorial prompts for returning players.
+  - Rollback: Revert the default state to disabled.
+
+- Test list (must fail first):
+  1) `tutorial_state.spec`: `isEnabled()` returns true by default (must fail first).

--- a/src/__tests__/tutorial_state.spec.ts
+++ b/src/__tests__/tutorial_state.spec.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { isEnabled } from '../tutorial/state'
+
+const KEY = 'eclipse-tutorial-v1'
+
+describe('tutorial state', () => {
+  beforeEach(() => {
+    localStorage.removeItem(KEY)
+  })
+
+  it('is enabled by default', () => {
+    expect(isEnabled()).toBe(true)
+  })
+})

--- a/src/tutorial/state.ts
+++ b/src/tutorial/state.ts
@@ -35,7 +35,7 @@ type TutorialState = {
 };
 
 const KEY = 'eclipse-tutorial-v1';
-const DEFAULT_STATE: TutorialState = { enabled: false, completed: false, step: 'intro-combat' };
+const DEFAULT_STATE: TutorialState = { enabled: true, completed: false, step: 'intro-combat' };
 
 function read(): TutorialState {
   if (typeof localStorage === 'undefined') return { ...DEFAULT_STATE };


### PR DESCRIPTION
## Summary
- Turn on the tutorial by default for new players by updating the default state.
- Add a unit test ensuring `isEnabled()` is true when no tutorial state exists in localStorage.
- Document plan entry for enabling tutorial by default.

## Testing
- `npm run test:run -- src/__tests__/tutorial_state.spec.ts`
- `npm run test:run -- src/__tests__/tutorial_enemy_softening.spec.ts`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c5a61c70bc8333b882f9e1ec718262