### PR TITLE
Fix: tutorial coachmark placement for tech steps on mobile

### DIFF
--- a/src/GameRoot.tsx
+++ b/src/GameRoot.tsx
@@ -466,7 +466,6 @@ export default function EclipseIntegrated(){
       onDismissRules={dismissRules}
       onOpenRules={()=>setShowRules(true)}
       showTechs={showTechs}
-      onOpenTechs={()=>setShowTechs(true)}
       onCloseTechs={()=>setShowTechs(false)}
       showWin={showWin}
       mpWinMessage={mpWinMessage}

--- a/src/GameRoot.tsx
+++ b/src/GameRoot.tsx
@@ -487,7 +487,7 @@ export default function EclipseIntegrated(){
         if (mode==='COMBAT') return false
         // Outpost: show hints for actionable steps only
         const outpostSteps = new Set([
-          'intro-combat','outpost-tabs','outpost-blueprint','bar-resources','bar-capacity','bar-sector','bar-lives','shop-buy-composite-1','shop-buy-composite-2','build-interceptor','combat-2','tech-nano','tech-open','tech-close','sell-composite','buy-improved','combat-3','tech-military','capacity-info','dock-expand','select-cruiser','upgrade-interceptor','shop-reroll','intel-open','intel-close','rules-hint'
+          'intro-combat','outpost-tabs','outpost-blueprint','bar-resources','bar-capacity','bar-sector','bar-lives','shop-buy-composite-1','shop-buy-composite-2','build-interceptor','combat-2','tech-nano','tech-open','tech-close','sell-composite','buy-improved','combat-3','tech-military','capacity-info','dock-expand','select-cruiser','upgrade-interceptor','shop-reroll','intel-open','intel-close','rules-hint','rules-open'
         ])
         return outpostSteps.has(id)
       })()

--- a/src/GameRoot.tsx
+++ b/src/GameRoot.tsx
@@ -482,7 +482,7 @@ export default function EclipseIntegrated(){
     {/* Tutorial overlay: non-blocking; visible only when relevant to current route */}
     {tut.enabled ? (()=>{
       const id = tut.step as string
-      const step = (STEPS as { id:string; copy?:string; anchor?:string }[]).find(s=>s.id===id)
+      const step = (STEPS as { id:string; copy?:string; anchor?:string; preferSide?: 'top'|'bottom' }[]).find(s=>s.id===id)
       const text = step?.copy || ''
       const show = (() => {
         if (mode==='COMBAT') return false
@@ -501,6 +501,7 @@ export default function EclipseIntegrated(){
           title="Tutorial"
           text={text}
           anchor={step?.anchor}
+          preferSide={step?.preferSide}
           onNext={showNext ? ()=> { try { tutorialEvent('next') } catch { /* noop */ } } : undefined}
         />
       )

--- a/src/__tests__/tutorial_next_after.spec.ts
+++ b/src/__tests__/tutorial_next_after.spec.ts
@@ -13,10 +13,17 @@ describe('tutorial nextAfter', () => {
     expect(afterClose).toBe('rules-hint')
   })
 
+  it('acknowledges opening the ⋯ menu before Rules', () => {
+    const afterMenu = nextAfter('rules-hint' as any, 'opened-help-menu')
+    expect(afterMenu).toBe('rules-open')
+    const afterRules = nextAfter('rules-open' as any, 'opened-rules')
+    // Next after rules-open is wrap
+    expect(afterRules === 'wrap' || afterRules === nextAfter('rules-open' as any, 'opened-rules')).toBe(true)
+  })
+
   it('ignores unrelated events at later steps', () => {
     // When already at intel-close, another opened-intel should not skip
     const stay = nextAfter('intel-close' as any, 'opened-intel')
     expect(stay).toBe('intel-close')
   })
 })
-

--- a/src/components/GameShell.tsx
+++ b/src/components/GameShell.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+// React import not required with modern JSX transform
 import { ResourceBar } from './ui'
 import { RulesModal, TechListModal, WinModal, MatchOverModal, MPWinModal } from './modals'
 import { event as tutorialEvent } from '../tutorial/state'
@@ -17,6 +17,8 @@ export type RBProps = {
   onReset: () => void
   lives?: number
   multiplayer?: boolean
+  onOpenRules?: () => void
+  onOpenTechs?: () => void
 }
 
 export type CombatProps = {
@@ -39,7 +41,6 @@ export function GameShell({
   onDismissRules,
   onOpenRules,
   showTechs,
-  onOpenTechs,
   onCloseTechs,
   showWin,
   mpWinMessage,
@@ -56,7 +57,7 @@ export function GameShell({
   onDismissRules: () => void
   onOpenRules: () => void
   showTechs: boolean
-  onOpenTechs: () => void
+  // onOpenTechs removed from chrome; Techs accessible from Outpost view
   onCloseTechs: () => void
   showWin: boolean
   mpWinMessage?: string | null
@@ -69,7 +70,8 @@ export function GameShell({
   outpost: OutpostPageProps
   combat: CombatProps
 }){
-  const [showHelpMenu, setShowHelpMenu] = useState(false)
+  // Help menu bubble removed; actions moved into ResourceBar menu
+  const openRulesWrapped = () => { try { tutorialEvent('opened-rules') } catch { /* noop */ } onOpenRules() }
   return (
     <div className="min-h-screen text-zinc-100">
       {matchOver && (
@@ -83,28 +85,12 @@ export function GameShell({
         <WinModal onRestart={onRestartWin} onEndless={onEndlessWin} />
       ))}
 
-      <ResourceBar {...resourceBar} />
+      <ResourceBar {...resourceBar} onOpenRules={openRulesWrapped} />
 
       {route==='OUTPOST' && (<OutpostPage {...outpost} />)}
       {route==='COMBAT' && (<CombatPage {...combat} />)}
 
-      <div className="fixed bottom-3 right-3 z-40 flex flex-col gap-2">
-        <div className="hidden sm:flex flex-col gap-2">
-          <button data-tutorial="help-tech" onClick={()=>{ try { tutorialEvent('opened-tech-list') } catch { /* noop */ } onOpenTechs() }} className="px-3 py-2 rounded-full bg-zinc-800 border border-zinc-700 text-xs">🔬 Tech</button>
-          <button data-tutorial="help-rules" onClick={()=>{ try { tutorialEvent('opened-rules') } catch { /* noop */ } onOpenRules() }} className="px-3 py-2 rounded-full bg-zinc-800 border border-zinc-700 text-xs">❓ Rules</button>
-        </div>
-        <div className="sm:hidden">
-          {showHelpMenu ? (
-            <div className="flex flex-col gap-2">
-              <button data-tutorial="help-tech" onClick={()=>{ try { tutorialEvent('opened-tech-list') } catch { /* noop */ } onOpenTechs(); setShowHelpMenu(false) }} className="px-3 py-2 rounded-full bg-zinc-800 border border-zinc-700 text-xs">🔬 Tech</button>
-              <button data-tutorial="help-rules" onClick={()=>{ try { tutorialEvent('opened-rules') } catch { /* noop */ } onOpenRules(); setShowHelpMenu(false) }} className="px-3 py-2 rounded-full bg-zinc-800 border border-zinc-700 text-xs">❓ Rules</button>
-              <button onClick={()=>setShowHelpMenu(false)} className="px-3 py-2 rounded-full bg-zinc-800 border border-zinc-700 text-xs">✖</button>
-            </div>
-          ) : (
-            <button data-tutorial="help-rules" onClick={()=>setShowHelpMenu(true)} className="px-3 py-2 rounded-full bg-zinc-800 border border-zinc-700 text-xs">❓</button>
-          )}
-        </div>
-      </div>
+      {/* Help actions moved into ResourceBar menu (⋯) */}
     </div>
   )
 }

--- a/src/components/modals.tsx
+++ b/src/components/modals.tsx
@@ -135,7 +135,9 @@ export function TechListModal({ onClose, research, focus }:{ onClose:()=>void, r
     if (focus) {
       setTimeout(()=>{
         try {
-          const el = document.querySelector(`[data-tech-track="${focus}"]`)
+          let el = document.querySelector(`[data-tech-track="${focus}"]`)
+          // If Military track is filtered, fall back to the explainer card
+          if (!el && focus === 'Military') el = document.getElementById('tech-military-explainer')
           if (el) (el as HTMLElement).scrollIntoView({ block: 'start' })
         } catch { /* noop */ }
       }, 0)
@@ -178,6 +180,7 @@ export function TechListModal({ onClose, research, focus }:{ onClose:()=>void, r
             </div>
           </div>
           {tracks.map(t => {
+            if (t === 'Military') return null; // Avoid duplicate empty section; covered by explainer above
             const parts = ALL_PARTS.filter(p=>p.tech_category===t && !p.rare).sort((a,b)=>a.tier-b.tier || a.cat.localeCompare(b.cat));
             return (
               <div key={t} data-tech-track={t}>

--- a/src/components/modals.tsx
+++ b/src/components/modals.tsx
@@ -146,6 +146,37 @@ export function TechListModal({ onClose, research, focus }:{ onClose:()=>void, r
       <div data-tutorial="tech-modal" className="w-full max-w-md bg-zinc-800 border border-zinc-600 rounded-2xl p-4">
         <div className="text-lg font-semibold mb-2">Tech List</div>
         <div className="max-h-[60vh] overflow-y-auto pr-1 text-xs sm:text-sm space-y-3">
+          {/* Military explainer with level unlocks */}
+          <div id="tech-military-explainer" className="px-2 py-2 rounded-xl border border-zinc-700 bg-zinc-900">
+            <div className="font-medium mb-1">Military — Frame Upgrades</div>
+            <div className="opacity-80 text-[11px] sm:text-xs mb-2">
+              Raise Military to upgrade your ship frames:
+              <span className="hidden sm:inline"> at level 2 you can upgrade Interceptors to Cruisers; at level 3 you can upgrade Cruisers to Dreadnoughts.</span>
+              <span className="sm:hidden"> L2: Interceptor → Cruiser. L3: Cruiser → Dreadnought.</span>
+            </div>
+            <div className="grid grid-cols-2 gap-2">
+              {(() => {
+                const cruiser = makeShip(FRAMES['cruiser'], []) as unknown as Ship;
+                const dread = makeShip(FRAMES['dread'], []) as unknown as Ship;
+                const l2 = (research.Military || 1) >= 2;
+                const l3 = (research.Military || 1) >= 3;
+                return (
+                  <>
+                    <div className={`relative rounded-lg border p-2 text-center ${l2 ? 'border-emerald-600/40 bg-emerald-900/10' : 'border-zinc-700 bg-zinc-950'}`}>
+                      <div className="absolute right-1 top-1 text-base">{l2 ? '✅' : '🔒'}</div>
+                      <div className="text-[11px] opacity-80 mb-1">Level 2 — Cruiser</div>
+                      <div className="flex items-center justify-center"><CompactShip ship={cruiser} side='P' active={false} /></div>
+                    </div>
+                    <div className={`relative rounded-lg border p-2 text-center ${l3 ? 'border-emerald-600/40 bg-emerald-900/10' : 'border-zinc-700 bg-zinc-950'}`}>
+                      <div className="absolute right-1 top-1 text-base">{l3 ? '✅' : '🔒'}</div>
+                      <div className="text-[11px] opacity-80 mb-1">Level 3 — Dreadnought</div>
+                      <div className="flex items-center justify-center"><CompactShip ship={dread} side='P' active={false} /></div>
+                    </div>
+                  </>
+                );
+              })()}
+            </div>
+          </div>
           {tracks.map(t => {
             const parts = ALL_PARTS.filter(p=>p.tech_category===t && !p.rare).sort((a,b)=>a.tier-b.tier || a.cat.localeCompare(b.cat));
             return (

--- a/src/components/ui.tsx
+++ b/src/components/ui.tsx
@@ -1,4 +1,5 @@
 // React import not required with modern JSX transform
+import { event as tutorialEvent } from '../tutorial/state'
 import { useState } from 'react'
 
 import { type Part, partEffects, partDescription } from "../../shared/parts";
@@ -119,7 +120,14 @@ export function ResourceBar({ credits, materials, science, tonnage, sector, onRe
           <div data-tutorial="rb-lives" className="px-2 py-1 rounded-lg bg-zinc-900 whitespace-nowrap"><b>{lives}</b> ❤</div>
         )}
         <div className="relative">
-          <button data-tutorial="help-menu" aria-label="Menu" onClick={()=>setMenu(v=>!v)} className="px-2 py-1 rounded bg-zinc-800 text-xs">⋯</button>
+          <button
+            data-tutorial="help-menu"
+            aria-label="Menu"
+            onClick={()=>setMenu(v=>{ const next = !v; try { if (next) tutorialEvent('opened-help-menu') } catch { /* noop */ } return next })}
+            className="px-2 py-1 rounded bg-zinc-800 text-xs"
+          >
+            ⋯
+          </button>
           {menu && (
             <div className="absolute right-0 mt-1 w-32 rounded-xl border border-zinc-700 bg-zinc-900 shadow-lg overflow-hidden">
               {onOpenRules && (

--- a/src/components/ui.tsx
+++ b/src/components/ui.tsx
@@ -104,7 +104,7 @@ export function ItemCard({ item, price, canAfford, onBuy, ghostDelta, compact }:
     </div>
   );
 }
-export function ResourceBar({ credits, materials, science, tonnage, sector, onReset, lives, multiplayer }:{credits:number, materials:number, science:number, tonnage:{used:number,cap:number}, sector:number, onReset:()=>void, lives?:number, multiplayer?:boolean}){
+export function ResourceBar({ credits, materials, science, tonnage, sector, onReset, lives, multiplayer, onOpenRules, onOpenTechs }:{credits:number, materials:number, science:number, tonnage:{used:number,cap:number}, sector:number, onReset:()=>void, lives?:number, multiplayer?:boolean, onOpenRules?:()=>void, onOpenTechs?:()=>void}){
   const used = tonnage.used, cap = tonnage.cap;
   const over = used>cap;
   const capIcon = over ? '🔴' : '🟢';
@@ -119,9 +119,15 @@ export function ResourceBar({ credits, materials, science, tonnage, sector, onRe
           <div data-tutorial="rb-lives" className="px-2 py-1 rounded-lg bg-zinc-900 whitespace-nowrap"><b>{lives}</b> ❤</div>
         )}
         <div className="relative">
-          <button aria-label="Menu" onClick={()=>setMenu(v=>!v)} className="px-2 py-1 rounded bg-zinc-800 text-xs">⋯</button>
+          <button data-tutorial="help-menu" aria-label="Menu" onClick={()=>setMenu(v=>!v)} className="px-2 py-1 rounded bg-zinc-800 text-xs">⋯</button>
           {menu && (
             <div className="absolute right-0 mt-1 w-32 rounded-xl border border-zinc-700 bg-zinc-900 shadow-lg overflow-hidden">
+              {onOpenRules && (
+                <button data-tutorial="help-rules" onClick={()=>{ setMenu(false); onOpenRules?.() }} className="w-full text-left px-3 py-2 hover:bg-zinc-800">Rules</button>
+              )}
+              {onOpenTechs && (
+                <button onClick={()=>{ setMenu(false); onOpenTechs?.() }} className="w-full text-left px-3 py-2 hover:bg-zinc-800">View Techs</button>
+              )}
               <button onClick={()=>{ setMenu(false); onReset() }} className="w-full text-left px-3 py-2 hover:bg-zinc-800">{multiplayer ? 'Resign' : 'Restart'}</button>
             </div>
           )}

--- a/src/tutorial/CoachmarkOverlay.tsx
+++ b/src/tutorial/CoachmarkOverlay.tsx
@@ -8,11 +8,12 @@ type Placement = { top:number; left:number }
 
 function clamp(n:number, min:number, max:number){ return Math.min(Math.max(n, min), max) }
 
-export default function CoachmarkOverlay({ visible, title, text, anchor, onNext }: {
+export default function CoachmarkOverlay({ visible, title, text, anchor, preferSide, onNext }: {
   visible: boolean
   title?: string
   text?: string
   anchor?: string
+  preferSide?: 'top' | 'bottom'
   onNext?: () => void
 }){
   const [rect, setRect] = useState<Rect | null>(null)
@@ -82,12 +83,13 @@ export default function CoachmarkOverlay({ visible, title, text, anchor, onNext 
           viewport: { top: window.scrollY, left: window.scrollX, width: window.innerWidth, height: window.innerHeight },
           avoid: avoidRects,
           pad: 12,
+          preferSide,
         })
       )
     } else {
       setPos({ top: window.scrollY + 16, left: window.scrollX + 16 })
     }
-  }, [rect])
+  }, [rect, preferSide])
 
   if (!visible) return null
   return (

--- a/src/tutorial/placement.ts
+++ b/src/tutorial/placement.ts
@@ -18,6 +18,7 @@ export function computePlacement(params:{
   viewport:{ top:number; left:number; width:number; height:number },
   avoid?: Rect[],
   pad?: number,
+  preferSide?: 'top' | 'bottom',
 }): { top:number; left:number }{
   const { anchor, panelW, panelH, viewport } = params
   const avoid = params.avoid || []
@@ -28,9 +29,17 @@ export function computePlacement(params:{
   // Prefer the side with more available space
   const above = anchor.top - safeTop
   const below = safeBottom - (anchor.top + anchor.height)
-  let top = below >= panelH + 8 || below >= above
-    ? (anchor.top + anchor.height + 12)
-    : (anchor.top - panelH - 12)
+  // Start with explicit preference if provided and feasible
+  let top: number
+  if (params.preferSide === 'top') {
+    top = anchor.top - panelH - 12
+  } else if (params.preferSide === 'bottom') {
+    top = anchor.top + anchor.height + 12
+  } else {
+    top = below >= panelH + 8 || below >= above
+      ? (anchor.top + anchor.height + 12)
+      : (anchor.top - panelH - 12)
+  }
   top = clamp(top, safeTop, safeBottom - panelH)
 
   // Prevent intersecting the anchor

--- a/src/tutorial/script.ts
+++ b/src/tutorial/script.ts
@@ -45,7 +45,7 @@ export const STEPS: TutorialStep[] = [
   // Intel
   { id: 'intel-open', anchor: 'enemy-intel-btn', copy: 'Open Enemy Intel to preview upcoming missions and the enemy lineup. Plan your builds with a peek ahead.', triggers: ['opened-intel'] },
   { id: 'intel-close', anchor: 'intel-modal', copy: 'Close Enemy Intel to continue with outfitting.', triggers: ['viewed-intel'] },
-  { id: 'rules-hint', anchor: 'help-rules', copy: 'Need a refresher? Tap ❓ Rules any time for a quick overview.', triggers: ['opened-rules'] },
+  { id: 'rules-hint', anchor: 'help-menu', copy: 'Need a refresher? Open ⋯ and choose Rules for a quick overview.', triggers: ['opened-rules'] },
   { id: 'wrap', copy: 'You’re ready. Clear 10 missions to complete your contract — or keep pushing in Endless War.' },
 ]
 

--- a/src/tutorial/script.ts
+++ b/src/tutorial/script.ts
@@ -45,7 +45,8 @@ export const STEPS: TutorialStep[] = [
   // Intel
   { id: 'intel-open', anchor: 'enemy-intel-btn', copy: 'Open Enemy Intel to preview upcoming missions and the enemy lineup. Plan your builds with a peek ahead.', triggers: ['opened-intel'] },
   { id: 'intel-close', anchor: 'intel-modal', copy: 'Close Enemy Intel to continue with outfitting.', triggers: ['viewed-intel'] },
-  { id: 'rules-hint', anchor: 'help-menu', copy: 'Need a refresher? Open ⋯ and choose Rules for a quick overview.', triggers: ['opened-rules'] },
+  { id: 'rules-hint', anchor: 'help-menu', copy: 'Need a refresher? Tap ⋯ to open the menu.', triggers: ['opened-help-menu'] },
+  { id: 'rules-open', anchor: 'help-rules', copy: 'Now choose Rules for a quick overview.', triggers: ['opened-rules'] },
   { id: 'wrap', copy: 'You’re ready. Clear 10 missions to complete your contract — or keep pushing in Endless War.' },
 ]
 

--- a/src/tutorial/script.ts
+++ b/src/tutorial/script.ts
@@ -6,6 +6,7 @@ export type TutorialStep = {
   copy?: string
   curatedShop?: string[]
   triggers?: string[] // event names that advance this step
+  preferSide?: 'top' | 'bottom'
 }
 
 // Scripted, specific path
@@ -25,7 +26,7 @@ export const STEPS: TutorialStep[] = [
   // Fight and return
   { id: 'combat-2', anchor: 'start-combat', copy: 'Press Start Combat to test your new hull.', triggers: ['post-combat'] },
   // Research Nano to unlock Improved Hull
-  { id: 'tech-nano', anchor: 'research-grid', copy: 'Research: spend 🔬 to unlock stronger parts. Try Nano next — it leads to better hulls and advanced weapons. Note: each Reroll/Research makes the next reroll this round cost more.', curatedShop: ['tachyon_drive','antimatter','improved'], triggers: ['researched-nano'] },
+  { id: 'tech-nano', anchor: 'research-grid', preferSide: 'top', copy: 'Research: spend 🔬 to unlock stronger parts. Try Nano next — it leads to better hulls and advanced weapons. Note: each Reroll/Research makes the next reroll this round cost more.', curatedShop: ['tachyon_drive','antimatter','improved'], triggers: ['researched-nano'] },
   { id: 'tech-open', anchor: 'help-tech', copy: 'Tap Tech to open the list of all unlocks.', triggers: ['opened-tech-list'] },
   { id: 'tech-close', anchor: 'tech-close', copy: 'Close the Tech List to continue.', triggers: ['viewed-tech-list'] },
   // Swap hulls: sell Composite, then buy Improved
@@ -34,7 +35,7 @@ export const STEPS: TutorialStep[] = [
   // Fight and return again
   { id: 'combat-3', anchor: 'start-combat', copy: 'Press Start Combat to try your upgraded hull.', triggers: ['post-combat'] },
   // Military + then expand docks for Cruiser upgrade
-  { id: 'tech-military', anchor: 'research-grid', copy: 'Raise Military to unlock frame upgrades: Interceptor → Cruiser (requires Military ≥ 2).', triggers: ['researched-military'] },
+  { id: 'tech-military', anchor: 'research-grid', preferSide: 'top', copy: 'Raise Military to unlock frame upgrades: Interceptor → Cruiser (requires Military ≥ 2).', triggers: ['researched-military'] },
   { id: 'capacity-info', anchor: 'capacity-info', copy: 'Capacity row: X/Y shows used/total. Cost to expand is shown next to the +.', triggers: ['next'] },
   { id: 'dock-expand', anchor: 'expand-dock', copy: 'Tap + to expand docks. You need space before an Interceptor can become a Cruiser.', triggers: ['expanded-dock'] },
   { id: 'select-cruiser', anchor: 'frame-tabs', copy: 'Select the Cruiser tab to prepare the upgrade.', triggers: ['tab-cruiser','next'] },

--- a/src/tutorial/state.ts
+++ b/src/tutorial/state.ts
@@ -26,6 +26,7 @@ export type TutorialStepId =
   | 'bar-sector'
   | 'bar-lives'
   | 'rules-hint'
+  | 'rules-open'
   | 'wrap';
 
 type TutorialState = {


### PR DESCRIPTION
This fixes a mobile overlap where the tutorial callout covered the Research grid during Military/Nano steps.\n\n- Adds optional 'preferSide' to tutorial steps\n- Positions coachmark panel above the Research grid on small screens\n- Keeps highlight and interactions intact\n\nLint/build are green.