### PR TITLE
Prevent endless run battle log duplicates

### DIFF
--- a/src/hooks/useRunLifecycle.ts
+++ b/src/hooks/useRunLifecycle.ts
@@ -78,7 +78,7 @@ export function useRunLifecycle(params: {
         // Final victory
         const faction = getters.faction?.()
         const difficulty = getters.difficulty?.()
-        if (faction && difficulty) {
+        if (!endless && faction && difficulty) {
           try { fns.recordWin(faction, difficulty, research, culled) } catch { /* ignore */ }
         }
         try { fns.clearRunState() } catch { /* ignore */ }
@@ -87,6 +87,7 @@ export function useRunLifecycle(params: {
         if (!endless) {
           setters.setShowWin(true)
         } else {
+          try { setters.setSector?.((n)=> Math.max(n, sector) + 1) } catch { /* ignore */ }
           setters.setShop({ items: rollInventory(research) })
           setters.setShopVersion(v => v + 1)
         }


### PR DESCRIPTION
## Summary
- extend the run lifecycle victory harness to expose mock hooks and cover endless battle log behavior
- avoid recording progress wins once endless mode is active so the battle log only logs the run completion once

## Testing
- npx vitest run src/__tests__/hooks_useRunLifecycle_victory.spec.tsx
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c83f5f13ac833380f8814e001c5a3b