### PR TITLE
Fix Enemy Intel boss layout overflow

### DIFF
--- a/src/__tests__/boss.spec.tsx
+++ b/src/__tests__/boss.spec.tsx
@@ -46,6 +46,14 @@ describe('Boss variants and planning', () => {
     const texts = variantLines.map(el => el.parentElement?.textContent || '')
     expect(texts.join(' | ')).toMatch(/High Aim/i)
     expect(texts.join(' | ')).toMatch(/High Shields|Tanky/i)
+
+    // Boss rows should stack tonnage info beneath the fleet preview (no nowrap / flex-column layout)
+    const tonnageLabels = screen.getAllByText(/Enemy tonnage/i)
+    const bossLabel = tonnageLabels.find(el => el.parentElement?.textContent?.includes('(Boss)'))
+    expect(bossLabel).toBeTruthy()
+    expect(bossLabel?.className).not.toMatch(/whitespace-nowrap/)
+    const bossRow = bossLabel?.parentElement
+    expect(bossRow?.className || '').toMatch(/flex-col/)
   }, 20000)
 
   it('boss generation uses predefined opponent faction fleets at sector 5', () => {

--- a/src/components/modals.tsx
+++ b/src/components/modals.tsx
@@ -24,7 +24,7 @@ function BossFleetPreview({ sector }:{ sector:5|10 }){
   return (
     <div className="mt-1">
       <div className="text-[11px] opacity-80">Opponent: {oppName} — "{spec.name}"</div>
-      <div className="mt-1 flex gap-2 overflow-x-auto pb-1">
+      <div className="mt-1 flex flex-wrap gap-2 pb-1">
         {ships.map((sh, i)=>(<CompactShip key={i} ship={sh} side='E' active={false} />))}
       </div>
     </div>
@@ -103,7 +103,7 @@ export function CombatPlanModal({ onClose, sector, endless, gameMode, multi }:{ 
         ) : (
           <div className="text-xs sm:text-sm space-y-1 max-h-[60vh] overflow-y-auto pr-1">
             {plan.map(s=> (
-              <div key={s.sector} className="px-2 py-1 rounded bg-zinc-950 border border-zinc-800 flex items-start justify-between gap-2">
+              <div key={s.sector} className="px-2 py-1 rounded bg-zinc-950 border border-zinc-800 flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
                 <div className="flex-1">
                   <div>Sector {s.sector}{s.boss? ' (Boss)':''}</div>
                   {s.boss && (
@@ -113,7 +113,7 @@ export function CombatPlanModal({ onClose, sector, endless, gameMode, multi }:{ 
                     </>
                   )}
                 </div>
-                <div className="opacity-80 text-right whitespace-nowrap">Enemy tonnage {s.enemyTonnage} • Science cap T{s.enemyScienceCap}</div>
+                <div className="opacity-80 sm:text-right">Enemy tonnage {s.enemyTonnage} • Science cap T{s.enemyScienceCap}</div>
               </div>
             ))}
           </div>


### PR DESCRIPTION
## Summary
- stack single-player Enemy Intel boss cards vertically to prevent horizontal overflow
- allow boss fleet previews to wrap so ship minis stay within the modal width
- cover the stacked layout with a regression test for the boss tonnage label

## Testing
- npm run lint
- npx vitest run src/__tests__/enemy_intel_modal.spec.tsx
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c9cc6af1588333bfd3b59249b0c9b1