### PR TITLE
Implement shop reroll and purchase effects

### DIFF
--- a/src/__tests__/outpost_shop_effects.spec.ts
+++ b/src/__tests__/outpost_shop_effects.spec.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from 'vitest'
+import { applyOutpostCommand } from '../engine/commands'
+import type { OutpostEnv, OutpostState } from '../engine/state'
+import { makeShip, getFrame, ALL_PARTS } from '../game'
+import type { Part } from '../../shared/parts'
+import type { EffectfulPart } from '../../shared/effects'
+import type { Research, Resources } from '../../shared/defaults'
+
+const BASE_RESOURCES: Resources = { credits: 200, materials: 0, science: 0 }
+const BASE_RESEARCH: Research = { Military: 1, Grid: 1, Nano: 1 }
+
+function clonePart(id: string): EffectfulPart {
+  const base = (ALL_PARTS as EffectfulPart[]).find(p => p.id === id)
+  if (!base) throw new Error(`Unknown part ${id}`)
+  return {
+    ...base,
+    effects: base.effects?.map(e => ({ hook: e.hook, effect: { ...e.effect } })),
+  }
+}
+
+function makeState(parts: EffectfulPart[]): OutpostState {
+  const frame = getFrame('interceptor')
+  const ship = makeShip(frame, parts as Part[])
+  return {
+    resources: { ...BASE_RESOURCES },
+    research: { ...BASE_RESEARCH },
+    blueprints: {
+      interceptor: parts as Part[],
+      cruiser: [],
+      dread: [],
+    },
+    fleet: [ship],
+    capacity: { cap: 3 },
+    tonnageUsed: frame.tonnage,
+    focusedIndex: 0,
+    rerollCost: 8,
+    rerollsThisRun: 0,
+    shopVersion: 0,
+  }
+}
+
+describe('shop-triggered part effects', () => {
+  it('destroys parts with destroyOnShopReroll on reroll when the chance succeeds', () => {
+    const parts = [
+      clonePart('discount_source'),
+      clonePart('overtuned_drive'),
+      clonePart('plasma'),
+      clonePart('positron'),
+    ]
+    const state = makeState(parts)
+    const env: OutpostEnv = { gameMode: 'single', shopRng: () => 0 }
+
+    const { state: next } = applyOutpostCommand(state, env, { type: 'reroll' })
+
+    expect(next.blueprints.interceptor?.find(p => p.id === 'discount_source')).toBeUndefined()
+    expect(next.fleet[0].parts.find(p => p.id === 'discount_source')).toBeUndefined()
+  })
+
+  it('downgrades stats for downgradeOnReroll when triggered', () => {
+    const parts = [
+      clonePart('discount_source'),
+      clonePart('overtuned_drive'),
+      clonePart('plasma'),
+      clonePart('positron'),
+    ]
+    const state = makeState(parts)
+    const env: OutpostEnv = { gameMode: 'single', shopRng: () => 0 }
+
+    const { state: next } = applyOutpostCommand(state, env, { type: 'reroll' })
+    const drive = next.blueprints.interceptor?.find(p => p.id === 'overtuned_drive')
+
+    expect(drive?.init).toBe(1)
+    expect(next.fleet[0].parts.find(p => p.id === 'overtuned_drive')?.init).toBe(1)
+  })
+
+  it('destroys parts with destroyOnPurchase after buying an item', () => {
+    const parts = [
+      clonePart('discount_source'),
+      clonePart('fusion_drive'),
+      clonePart('plasma'),
+      clonePart('unstable_shield'),
+    ]
+    const state = makeState(parts)
+    const env: OutpostEnv = { gameMode: 'single', shopRng: () => 0 }
+
+    const buyPart = clonePart('positron')
+    const { state: next } = applyOutpostCommand(state, env, { type: 'buy_and_install', part: buyPart as Part })
+
+    expect(next.blueprints.interceptor?.find(p => p.id === 'unstable_shield')).toBeUndefined()
+    expect(next.fleet[0].parts.find(p => p.id === 'unstable_shield')).toBeUndefined()
+  })
+})

--- a/src/engine/shopEffects.ts
+++ b/src/engine/shopEffects.ts
@@ -1,0 +1,89 @@
+import type { EffectfulPart } from '../../shared/effects'
+import type { Part } from '../../shared/parts'
+import type { Ship } from '../../shared/types'
+import { getFrame, makeShip, type FrameId } from '../game'
+
+export type ShopEffectHook = 'onShopReroll' | 'onShopPurchase'
+
+export type ShopEffectState = {
+  blueprints: Record<FrameId, Part[]>
+  fleet: Ship[]
+}
+
+export function applyShopEffects(
+  state: ShopEffectState,
+  hook: ShopEffectHook,
+  rng: () => number,
+): ShopEffectState {
+  const changes = new Map<FrameId, EffectfulPart[]>()
+
+  for (const [frameId, parts] of Object.entries(state.blueprints) as [FrameId, Part[]][]) {
+    if (!parts || parts.length === 0) continue
+
+    let mutated = false
+    const kept: EffectfulPart[] = []
+
+    for (const original of parts as EffectfulPart[]) {
+      const hooks = original.effects?.filter(e => e.hook === hook)
+      if (!hooks || hooks.length === 0) {
+        kept.push(original)
+        continue
+      }
+
+      let current: EffectfulPart = original
+      let removed = false
+
+      for (const { effect } of hooks) {
+        if (effect.kind === 'destroyOnShopReroll' && hook === 'onShopReroll') {
+          if (rng() * 100 < effect.chancePct) {
+            removed = true
+            mutated = true
+            break
+          }
+        } else if (effect.kind === 'destroyOnPurchase' && hook === 'onShopPurchase') {
+          if (rng() * 100 < effect.chancePct) {
+            removed = true
+            mutated = true
+            break
+          }
+        } else if (effect.kind === 'downgradeOnReroll' && hook === 'onShopReroll') {
+          if (rng() * 100 < effect.chancePct) {
+            const stat = effect.stat as keyof Part
+            const currVal = typeof current[stat] === 'number' ? (current[stat] as number) : 0
+            const nextVal = Math.max(effect.min, currVal - 1)
+            if (nextVal !== currVal) {
+              current = { ...current, [stat]: nextVal } as EffectfulPart
+              mutated = true
+            }
+          }
+        }
+      }
+
+      if (!removed) {
+        kept.push(current)
+      }
+    }
+
+    if (mutated) {
+      changes.set(frameId, kept)
+    }
+  }
+
+  if (changes.size === 0) {
+    return state
+  }
+
+  const nextBlueprints = { ...state.blueprints }
+  for (const [frameId, updatedParts] of changes.entries()) {
+    nextBlueprints[frameId] = updatedParts as Part[]
+  }
+
+  const nextFleet = state.fleet.map(ship => {
+    const frameId = ship.frame.id as FrameId
+    if (!changes.has(frameId)) return ship
+    const parts = nextBlueprints[frameId] ?? []
+    return makeShip(getFrame(frameId), parts) as Ship
+  })
+
+  return { blueprints: nextBlueprints, fleet: nextFleet }
+}

--- a/src/engine/state.ts
+++ b/src/engine/state.ts
@@ -20,4 +20,5 @@ export type OutpostState = {
 export type OutpostEnv = {
   gameMode: 'single' | 'multiplayer'
   economyMods?: EconMods
+  shopRng?: () => number
 }


### PR DESCRIPTION
## Summary
- add a shop effects helper that can destroy or downgrade parts when rerolls or purchases trigger hooks
- integrate shop hook processing into buy and reroll commands with optional RNG injection
- add coverage ensuring overtuned parts lose stats or get removed when their shop risks fire

## Testing
- npm run lint
- npm run build
- npx vitest run src/__tests__/outpost_shop_effects.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68cb30609dfc8333a60fc0298796462d