### PR TITLE
Fix multi-slot part display in blueprint summary and frames

### DIFF
--- a/src/__tests__/frameSlots.spec.tsx
+++ b/src/__tests__/frameSlots.spec.tsx
@@ -8,17 +8,18 @@ describe('CompactShip frame slot display', () => {
   it('fills slots according to part slot usage', () => {
     const src = PARTS.sources[0]
     const comp = PARTS.computers.find(p => p.id === 'gluon')!
-    const weapon = PARTS.weapons.find(p => p.id === 'antimatter_array')!
+    const weapon = PARTS.weapons.find(p => p.slots === 2)!
     const ship = makeShip(getFrame('interceptor'), [src, comp, weapon])
     render(<CompactShip ship={ship} side="P" active={false} />)
     const used = ship.parts.reduce((a, p) => a + (p.slots || 1), 0)
     const filled = screen.getAllByTestId('frame-slot-filled')
-    expect(filled.length).toBe(ship.parts.length)
+    expect(filled.length).toBe(used)
     expect(screen.getAllByTestId('frame-slot-empty').length).toBe(Math.max(0, ship.frame.tiles - used))
     const icons = filled.map(el => el.textContent || '')
     expect(icons.some(t => t.includes('3⚡'))).toBe(true)
     expect(icons.some(t => t.includes('2🎯'))).toBe(true)
-    expect(icons.some(t => t.includes('2🎲2💥'))).toBe(true)
+    expect(icons.some(t => t.includes('3🎲') && t.includes('💥'))).toBe(true)
+    expect(icons.filter(t => t === '❌').length).toBe((weapon.slots || 1) - 1)
 
   })
 

--- a/src/__tests__/outpost_blueprint_summary.spec.tsx
+++ b/src/__tests__/outpost_blueprint_summary.spec.tsx
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+
+import BlueprintSummary from '../components/outpost/BlueprintSummary'
+import { getFrame, makeShip } from '../game'
+import { PARTS } from '../../shared/parts'
+
+describe('BlueprintSummary', () => {
+  it('counts multi-slot parts toward total slot usage', () => {
+    const source = PARTS.sources[0]
+    const drive = PARTS.drives[0]
+    const multiSlot = PARTS.weapons.find(p => p.slots === 2)!
+    const ship = makeShip(getFrame('interceptor'), [source, drive, multiSlot])
+
+    render(<BlueprintSummary ship={ship} />)
+
+    expect(screen.getByText(`⬛ 4/${ship.frame.tiles}`)).toBeInTheDocument()
+  })
+})

--- a/src/components/ShipFrameSlots.tsx
+++ b/src/components/ShipFrameSlots.tsx
@@ -102,9 +102,15 @@ export function ShipFrameSlots({ ship, side, active: _active }: { ship: Ship, si
     while (tokens.length < (ship.frame.tiles || 3)) tokens.push('');
     tokens.slice(0, ship.frame.tiles).forEach(lbl => cells.push({ slots: 1, label: lbl }));
   }
-  const used = cells.reduce((a, p) => a + p.slots, 0);
+  const filledLabels = cells.flatMap(({ slots, label }) => {
+    const count = Math.max(1, slots || 1);
+    if (count === 1) return [label];
+    const extras = Array(count - 1).fill('❌');
+    return [label, ...extras];
+  });
+  const used = filledLabels.length;
   const empties = Math.max(0, ship.frame.tiles - used);
-  const labels = cells.map(p => p.label).concat(Array(empties).fill(''));
+  const labels = filledLabels.concat(Array(empties).fill(''));
   let idx = 0;
   const glow = side === 'P'
     ? 'ring-sky-400 shadow-[0_0_4px_#38bdf8]'

--- a/src/components/outpost/BlueprintSummary.tsx
+++ b/src/components/outpost/BlueprintSummary.tsx
@@ -4,6 +4,7 @@ import type { Ship } from '../../../shared/types'
 
 export default function BlueprintSummary({ ship }:{ ship: Ship | undefined }){
   if (!ship) return null
+  const slotsUsed = ship.parts.reduce((total, part) => total + (part.slots || 1), 0)
   return (
     <div className="flex items-center gap-2 text-xs sm:text-sm mb-2">
       <PowerBadge use={ship.stats.powerUse} prod={ship.stats.powerProd} />
@@ -11,7 +12,7 @@ export default function BlueprintSummary({ ship }:{ ship: Ship | undefined }){
       <span>🎯 {ship.stats.aim}</span>
       <span>🛡️ {ship.stats.shieldTier}</span>
       <span>❤️ {ship.stats.hullCap}</span>
-      <span>⬛ {ship.parts.length}/{ship.frame.tiles}</span>
+      <span>⬛ {slotsUsed}/{ship.frame.tiles}</span>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- compute blueprint slot usage with part slot counts so multi-slot upgrades are reflected
- render filled placeholders for additional occupied frame slots so multi-slot parts no longer hide cells
- add regression tests covering blueprint summary and frame slot multi-slot behaviour

## Testing
- npx vitest run src/__tests__/outpost_blueprint_summary.spec.tsx src/__tests__/frameSlots.spec.tsx
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cda130c9448333a5e84a6e015ed95f