### PR TITLE
Refactor Outpost blueprint panel into dedicated component

### DIFF
--- a/coding_agents/subagents/planning_agent.md
+++ b/coding_agents/subagents/planning_agent.md
@@ -1,3 +1,25 @@
+## Plan Entry — Outpost Blueprint Panel Extraction
+
+- Outcome: Refactor the Outpost blueprint grid into a dedicated component with reusable card rendering so the page stays readable while preserving the info toggle UX.
+
+- Acceptance criteria:
+  - `OutpostPage` renders a new `<BlueprintPanel>` (or similarly named) component instead of inline blueprint markup.
+  - The panel owns a blueprint card subcomponent that handles the question-mark info toggle and Sell button.
+  - Toggling info still reveals the part description and resets when switching frames.
+  - Lint, targeted tests that import the new component, and build all pass.
+
+- Risks & rollback:
+  - Risk: Prop threading mistakes break blueprint info toggles. Mitigation: unit-style render via existing Outpost smoke tests.
+  - Risk: Missing exports/import loops. Mitigation: co-locate the card inside the new component file.
+  - Rollback: Revert the new component file and restore the previous inline markup in `OutpostPage`.
+
+- Test list (must fail first):
+  1. `outpost_dock_roster_smoke.spec.tsx` covers rendering the blueprint grid.
+  2. `dock.spec.tsx` exercises Outpost interactions and ensures blueprint actions mount.
+  3. `mp_blueprint_first_render.spec.tsx` ensures blueprint ids map correctly before Outpost mounts.
+
+---
+
 ## Plan Entry — Public Multiplayer Lobby
 
 - Outcome: Players can browse and join public multiplayer rooms; list shows host name, lives remaining, and starting ships; joining navigates to the room and removes it from the public list.

--- a/src/components/outpost/BlueprintPanel.tsx
+++ b/src/components/outpost/BlueprintPanel.tsx
@@ -1,0 +1,81 @@
+import { useEffect, useState } from 'react'
+import type { FrameId } from '../../../shared/frames'
+import { partDescription, partEffects, type Part } from '../../../shared/parts'
+
+type BlueprintPanelProps = {
+  frameId: FrameId
+  parts: Part[]
+  sellFrameId: FrameId | null
+  onSell: (frameId: FrameId, partIndex: number) => void
+}
+
+type BlueprintCardProps = {
+  part: Part
+  isOpen: boolean
+  onToggle: () => void
+  onSell: () => void
+  canSell: boolean
+}
+
+export default function BlueprintPanel({ frameId, parts, sellFrameId, onSell }: BlueprintPanelProps){
+  const [infoIdx, setInfoIdx] = useState<number | null>(null)
+
+  useEffect(() => {
+    setInfoIdx(null)
+  }, [frameId, parts])
+
+  const canSell = sellFrameId !== null
+
+  return (
+    <div data-tutorial="blueprint-panel" className="grid grid-cols-2 sm:grid-cols-3 gap-2">
+      {parts.map((part, idx) => (
+        <BlueprintCard
+          key={part.id ?? idx}
+          part={part}
+          isOpen={infoIdx === idx}
+          onToggle={() => setInfoIdx(infoIdx === idx ? null : idx)}
+          onSell={() => {
+            if (sellFrameId) onSell(sellFrameId, idx)
+          }}
+          canSell={canSell}
+        />
+      ))}
+    </div>
+  )
+}
+
+function BlueprintCard({ part, isOpen, onToggle, onSell, canSell }: BlueprintCardProps){
+  const effects = partEffects(part)
+  const refund = Math.floor((part.cost || 0) * 0.25)
+
+  return (
+    <div className="p-2 rounded border border-zinc-700 bg-zinc-900 text-xs">
+      <div className="font-medium text-sm">{part.name}</div>
+      <div className="opacity-70">{`${part.cat} • Tier ${part.tier}${effects.length ? ' • ' + effects.join(' • ') : ''}`}</div>
+      <div className="mt-1 flex justify-between items-center gap-2">
+        <span className="opacity-70">Refund {refund}¢</span>
+        <div className="flex items-center gap-1">
+          <button
+            aria-label="Part info"
+            onClick={onToggle}
+            className="px-2 py-1 rounded bg-zinc-900 border border-zinc-700"
+          >
+            ?
+          </button>
+          <button
+            onClick={onSell}
+            disabled={!canSell}
+            className={`px-2 py-1 rounded bg-rose-600 ${canSell ? '' : 'opacity-60 cursor-not-allowed'}`}
+          >
+            Sell
+          </button>
+        </div>
+      </div>
+      {isOpen && (
+        <div className="mt-2 text-[11px] opacity-90">
+          {partDescription(part)}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/pages/OutpostPage.tsx
+++ b/src/pages/OutpostPage.tsx
@@ -12,7 +12,7 @@ import { FRAMES, type FrameId } from '../../shared/frames'
 // import { ALL_PARTS } from '../../shared/parts'
 // import { groupFleet } from '../game/fleet'
 import { canBuildInterceptorWithMods } from '../game/hangar'
-import { partEffects } from '../../shared/parts'
+import BlueprintPanel from '../components/outpost/BlueprintPanel'
 import { type Resources, type Research } from '../../shared/defaults'
 import { type Part } from '../../shared/parts'
 import { type Ship, type GhostDelta } from '../../shared/types'
@@ -118,6 +118,7 @@ export function OutpostPage({
   const rrInc = applyEconomyModifiers(ECONOMY.reroll.increment, economyMods, 'credits');
   const currentClassId = hasSelected ? (focusedShip?.frame.id as FrameId) : selectedId;
   const currentBlueprint = blueprints[currentClassId] || [];
+  const sellFrameId = hasSelected && focusedShip ? (focusedShip.frame.id as FrameId) : null;
   const nextUpgrade = (()=>{
     if(!focusedShip) return null;
     if(focusedShip.frame.id==='interceptor') return {
@@ -263,17 +264,12 @@ export function OutpostPage({
               )}
               <ShipFrameSlots ship={hasSelected ? (focusedShip as Ship) : emptyShip(selectedId)} side='P' />
             </div>
-            <div data-tutorial="blueprint-panel" className="grid grid-cols-2 sm:grid-cols-3 gap-2">
-              {currentBlueprint.map((p, idx)=> (
-              <div key={idx} className="p-2 rounded border border-zinc-700 bg-zinc-900 text-xs">
-                <div className="font-medium text-sm">{p.name}</div>
-                <div className="opacity-70">{(() => { const eff = partEffects(p).join(' • '); return `${p.cat} • Tier ${p.tier}${eff ? ' • ' + eff : ''}`; })()}</div>
-                <div className="mt-1 flex justify-between items-center">
-                  <span className="opacity-70">Refund {Math.floor((p.cost||0)*0.25)}¢</span>
-                  <button onClick={()=> sellPart(focusedShip.frame.id as FrameId, idx)} className="px-2 py-1 rounded bg-rose-600">Sell</button>
-                </div>
-              </div>
-            ))}
+            <BlueprintPanel
+              frameId={currentClassId}
+              parts={currentBlueprint}
+              sellFrameId={sellFrameId}
+              onSell={(frameId, idx) => sellPart(frameId, idx)}
+            />
           </div>
           {/* Capacity below blueprint */}
           <div className="mt-2 grid grid-cols-1 gap-2">
@@ -334,12 +330,9 @@ export function OutpostPage({
           </div>
         </div>
       </div>
-      </div>
-
-
       {/* Start Combat */}
       <div className="fixed bottom-0 left-0 w-full z-10 p-3 bg-zinc-950/95 backdrop-blur border-t border-zinc-800">
-      <div className="mx-auto max-w-5xl flex items-center gap-2">
+        <div className="mx-auto max-w-5xl flex items-center gap-2">
           {(() => {
             const guards = mpGuards || undefined;
             const amReady = guards ? Boolean(guards.myReady) : Boolean(myReady);


### PR DESCRIPTION
## Summary
- document the blueprint panel refactor plan for this session
- extract the Outpost blueprint grid into a BlueprintPanel component with an inline card renderer
- thread the new panel through OutpostPage while keeping sell handling and start-combat layout tidy

## Testing
- npm run lint
- npx vitest run --pool=threads --maxWorkers=1 src/__tests__/outpost_dock_roster_smoke.spec.tsx src/__tests__/dock.spec.tsx src/__tests__/mp_blueprint_first_render.spec.tsx
- npm run build


------
https://chatgpt.com/codex/tasks/task_e_68cda03db6ac83338656a34ae60f97fb