### PR TITLE
Refactor Outpost blueprint panel into dedicated component and fix tech modal overlap

### DIFF
--- a/coding_agents/subagents/planning_agent.md
+++ b/coding_agents/subagents/planning_agent.md
@@ -1,3 +1,25 @@
+## Plan Entry — Outpost Blueprint Panel Extraction
+
+- Outcome: Refactor the Outpost blueprint grid into a dedicated component with reusable card rendering so the page stays readable while preserving the info toggle UX.
+
+- Acceptance criteria:
+  - `OutpostPage` renders a new `<BlueprintPanel>` (or similarly named) component instead of inline blueprint markup.
+  - The panel owns a blueprint card subcomponent that handles the question-mark info toggle and Sell button.
+  - Toggling info still reveals the part description and resets when switching frames.
+  - Lint, targeted tests that import the new component, and build all pass.
+
+- Risks & rollback:
+  - Risk: Prop threading mistakes break blueprint info toggles. Mitigation: unit-style render via existing Outpost smoke tests.
+  - Risk: Missing exports/import loops. Mitigation: co-locate the card inside the new component file.
+  - Rollback: Revert the new component file and restore the previous inline markup in `OutpostPage`.
+
+- Test list (must fail first):
+  1. `outpost_dock_roster_smoke.spec.tsx` covers rendering the blueprint grid.
+  2. `dock.spec.tsx` exercises Outpost interactions and ensures blueprint actions mount.
+  3. `mp_blueprint_first_render.spec.tsx` ensures blueprint ids map correctly before Outpost mounts.
+
+---
+
 ## Plan Entry — Public Multiplayer Lobby
 
 - Outcome: Players can browse and join public multiplayer rooms; list shows host name, lives remaining, and starting ships; joining navigates to the room and removes it from the public list.

--- a/src/components/outpost/BlueprintPanel.tsx
+++ b/src/components/outpost/BlueprintPanel.tsx
@@ -1,0 +1,81 @@
+import { useEffect, useState } from 'react'
+import type { FrameId } from '../../../shared/frames'
+import { partDescription, partEffects, type Part } from '../../../shared/parts'
+
+type BlueprintPanelProps = {
+  frameId: FrameId
+  parts: Part[]
+  sellFrameId: FrameId | null
+  onSell: (frameId: FrameId, partIndex: number) => void
+}
+
+type BlueprintCardProps = {
+  part: Part
+  isOpen: boolean
+  onToggle: () => void
+  onSell: () => void
+  canSell: boolean
+}
+
+export default function BlueprintPanel({ frameId, parts, sellFrameId, onSell }: BlueprintPanelProps){
+  const [infoIdx, setInfoIdx] = useState<number | null>(null)
+
+  useEffect(() => {
+    setInfoIdx(null)
+  }, [frameId, parts])
+
+  const canSell = sellFrameId !== null
+
+  return (
+    <div data-tutorial="blueprint-panel" className="grid grid-cols-2 sm:grid-cols-3 gap-2">
+      {parts.map((part, idx) => (
+        <BlueprintCard
+          key={part.id ?? idx}
+          part={part}
+          isOpen={infoIdx === idx}
+          onToggle={() => setInfoIdx(infoIdx === idx ? null : idx)}
+          onSell={() => {
+            if (sellFrameId) onSell(sellFrameId, idx)
+          }}
+          canSell={canSell}
+        />
+      ))}
+    </div>
+  )
+}
+
+function BlueprintCard({ part, isOpen, onToggle, onSell, canSell }: BlueprintCardProps){
+  const effects = partEffects(part)
+  const refund = Math.floor((part.cost || 0) * 0.25)
+
+  return (
+    <div className="p-2 rounded border border-zinc-700 bg-zinc-900 text-xs">
+      <div className="font-medium text-sm">{part.name}</div>
+      <div className="opacity-70">{`${part.cat} • Tier ${part.tier}${effects.length ? ' • ' + effects.join(' • ') : ''}`}</div>
+      <div className="mt-1 flex justify-between items-center gap-2">
+        <span className="opacity-70">Refund {refund}¢</span>
+        <div className="flex items-center gap-1">
+          <button
+            aria-label="Part info"
+            onClick={onToggle}
+            className="px-2 py-1 rounded bg-zinc-900 border border-zinc-700"
+          >
+            ?
+          </button>
+          <button
+            onClick={onSell}
+            disabled={!canSell}
+            className={`px-2 py-1 rounded bg-rose-600 ${canSell ? '' : 'opacity-60 cursor-not-allowed'}`}
+          >
+            Sell
+          </button>
+        </div>
+      </div>
+      {isOpen && (
+        <div className="mt-2 text-[11px] opacity-90">
+          {partDescription(part)}
+        </div>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- document the blueprint panel refactor plan for this session
- extract the Outpost blueprint grid into a BlueprintPanel component with an inline card renderer
- thread the new panel through OutpostPage while keeping sell handling and start-combat layout tidy
- hide the fixed Start Combat bar while Outpost overlays are visible so tech and intel modals aren't obstructed

## Testing
- npm run lint
- npx vitest run --pool=threads --maxWorkers=1 src/__tests__/outpost_dock_roster_smoke.spec.tsx src/__tests__/dock.spec.tsx src/__tests__/mp_blueprint_first_render.spec.tsx
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cda03db6ac83338656a34ae60f97fb